### PR TITLE
Update docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 0.1.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: Huang
+  given-names: Xin
+orcid: https://orcid.org/0000-0002-9918-9602
+title: GAISHI: A Python Package for Genomic Analysis of Introgressed-Site and -Haplotype Identification
+version: v0.1.0
+date-released: 2026-01-05

--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@
 
 A Python Package for **G**enomic **A**nalysis of **I**ntrogressed-**S**ite and -**H**aplotype **I**dentification
 
+The **OFFICIAL** repository: https://github.com/xin-huang/gaishi
+
+Contributions, bug reports, and feature requests should be directed to [the official repository](https://github.com/xin-huang/gaishi). If you are viewing a fork, please note that it may diverge from **the official repository** and is not maintained by the official maintainers. Please refer to **the official repository** for current releases, documentation, and contribution guidelines. When citing this software, cite **the official repository**, and use **official releases** for production or reproducible analyses.
+
 The manual can be found [here](https://xin-huang.github.io/gaishi).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,10 @@
 # GAISHI
 
 `gaishi` is a Python package for **G**enomic **A**nalysis of **I**ntrogressed-**S**ite and -**H**aplotype **Identification** using machine learning. 
-Currently, it supports two types of models:
+Currently, it supports three types of models:
 
 - Logistic regression models
+- Extra-trees classifiers
 - U-Net models
 
 `gaishi` uses established population genetic simulators like `msprime` for generating training and test data. 
@@ -65,3 +66,9 @@ This will display information for three commands:
 | eval | Evaluate model performance |
 
 If you need further help, such as reporting a bug or suggesting a feature, please open an [issue](https://github.com/xin-huang/gaishi/issues).
+
+## Important Notes
+
+The **OFFICIAL** repository: https://github.com/xin-huang/gaishi
+
+Contributions, bug reports, and feature requests should be directed to [the official repository](https://github.com/xin-huang/gaishi). If you are viewing a fork, please note that it may diverge from **the official repository** and is not maintained by the official maintainers. Please refer to **the official repository** for current releases, documentation, and contribution guidelines. When citing this software, cite **the official repository**, and use **official releases** for production or reproducible analyses.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,6 +1,6 @@
-site_name: gaigar
-site_url: "https://xin-huang.github.io/gaigar"
-repo_url: "https://github.com/xin-huang/gaigar"
+site_name: gaishi
+site_url: "https://xin-huang.github.io/gaishi"
+repo_url: "https://github.com/xin-huang/gaishi"
 edit_uri: ""
 docs_dir: 'docs'
 theme:
@@ -10,14 +10,14 @@ theme:
     accent: indigo
 plugins:
   - search
-  - mkdocstrings:
-      default_handler: python
-      handlers:
-        python:
-          rendering:
-            show_source: true
-      watch:
-        - gaigar
+#  - mkdocstrings:
+#      default_handler: python
+#      handlers:
+#        python:
+#          rendering:
+#            show_source: true
+#      watch:
+#        - gaishi
 markdown_extensions:
   - extra
   - tables


### PR DESCRIPTION
## Summary by Sourcery

Update project naming and documentation to reflect the gaishi repository and clarify its official status.

Documentation:
- Update site configuration and docs to use the gaishi name and repository URLs instead of gaigar.
- Document support for an additional Extra-trees classifier model alongside existing models.
- Add prominent notes in the README and docs directing users to the official gaishi repository for usage, issues, and contributions.

Chores:
- Add a CITATION.cff file to provide standardized citation metadata for the project.