### PR TITLE
Save weights as safetensors

### DIFF
--- a/build-env.yaml
+++ b/build-env.yaml
@@ -22,3 +22,4 @@ dependencies:
   - pip:
       - seriate==1.1.2
       - torch==2.2.0
+      - safetensors==0.4.5

--- a/dev-env.yaml
+++ b/dev-env.yaml
@@ -27,4 +27,5 @@ dependencies:
       - ortools==8.2.8710
       - git+https://github.com/xin-huang/seriate.git@dev
       - torch==2.2.0
+      - safetensors==0.4.5
       - -e .

--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -24,6 +24,7 @@ from typing import Optional
 import numpy as np
 import torch
 import torch.optim as optim
+from safetensors.torch import load_file, save_file
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from torch.nn import BCEWithLogitsLoss
@@ -221,7 +222,7 @@ class UNetModel(MlModel):
         net = net.to(device)
 
         if trained_model_file is not None:
-            checkpoint = torch.load(trained_model_file, map_location=device)
+            checkpoint = load_file(trained_model_file, device=device)
             net.load_state_dict(checkpoint)
 
         criterion = BCEWithLogitsLoss(pos_weight=torch.FloatTensor([ratio]).to(device))
@@ -297,7 +298,7 @@ class UNetModel(MlModel):
                 min_val_loss = val_loss
                 best_epoch = epoch_idx
                 add_msg = " Best weights saved."
-                torch.save(net.state_dict(), output)
+                save_file(net.state_dict(), output)
                 early_count = 0
             else:
                 early_count += 1
@@ -305,7 +306,7 @@ class UNetModel(MlModel):
                     add_msg = (
                         f" Early stopping; best weights at epoch {best_epoch} reloaded."
                     )
-                    net.load_state_dict(torch.load(output, map_location="cpu"))
+                    net.load_state_dict(load_file(output, device="cpu"))
             validation_log_file.write(log_msg + add_msg + "\n")
             validation_log_file.flush()
 
@@ -352,7 +353,7 @@ class UNetModel(MlModel):
         data : str
             Path to the input HDF5 file in the unified schema.
         model : str
-            Path to a PyTorch ``state_dict`` checkpoint (e.g. ``best.pth``).
+            Path to a ``.safetensors`` checkpoint (e.g. ``best.safetensors``).
         output : str
             Path to the output file.
         add_rnn : bool, optional
@@ -437,7 +438,7 @@ class UNetModel(MlModel):
                 net = UNetPlusPlus(num_classes=n_classes, input_channels=2)
                 input_channels = 2
 
-            ckpt = torch.load(model, map_location=dev)
+            ckpt = load_file(model, device=str(dev))
             net.load_state_dict(ckpt)
             net.to(dev)
             net.eval()

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -23,6 +23,7 @@ import numpy as np
 import os, pytest, torch
 import torch.nn as nn
 import gaishi.models.unet.unet_model as unet_mod
+from safetensors.torch import save_file
 
 
 class DummyUNetPlusPlus(nn.Module):
@@ -162,7 +163,7 @@ def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch) -> None:
     training_data = _make_training_h5(tmp_path, n_reps=40, N=2, L=7, with_gaps=True)
 
     model_dir = tmp_path / "model_out"
-    model_path = model_dir / "best.pth"
+    model_path = model_dir / "best.safetensors"
 
     unet_mod.UNetModel.train(
         data=training_data,
@@ -184,7 +185,7 @@ def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch) -> None:
 
     assert (model_dir / "training.log").exists()
     assert (model_dir / "validation.log").exists()
-    assert (model_dir / "best.pth").exists()
+    assert (model_dir / "best.safetensors").exists()
 
 
 def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch) -> None:
@@ -197,7 +198,7 @@ def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch) ->
     training_data = _make_training_h5(tmp_path, n_reps=40, N=3, L=11, with_gaps=True)
 
     model_dir = tmp_path / "model_out2"
-    model_path = model_dir / "best.pth"
+    model_path = model_dir / "best.safetensors"
 
     unet_mod.UNetModel.train(
         data=training_data,
@@ -225,7 +226,7 @@ def test_train_raises_when_add_rnn_true_but_missing_gap_datasets(
     training_data = _make_training_h5(tmp_path, n_reps=40, N=2, L=7, with_gaps=False)
 
     model_dir = tmp_path / "model_out3"
-    model_path = model_dir / "best.pth"
+    model_path = model_dir / "best.safetensors"
 
     # Your current pipeline will fail when trying to build 4-channel inputs without gap datasets.
     with pytest.raises(KeyError, match="Gap_to_prev|Gap_to_next"):
@@ -250,7 +251,7 @@ def test_train_raises_when_no_positive_class(tmp_path, monkeypatch) -> None:
     )
 
     model_dir = tmp_path / "model_out5"
-    model_path = model_dir / "best.pth"
+    model_path = model_dir / "best.safetensors"
 
     with pytest.raises(ValueError, match="no positive class"):
         unet_mod.UNetModel.train(
@@ -306,7 +307,7 @@ class DummyUNetPlusPlusRNN2(nn.Module):
 
 def _save_weights(tmp_path, model, filename) -> str:
     weights_path = tmp_path / filename
-    torch.save(model.state_dict(), str(weights_path))
+    save_file(model.state_dict(), str(weights_path))
 
     return str(weights_path)
 


### PR DESCRIPTION
### Motivation
- Keep the safetensors integration minimal and direct in the `UNetModel` as requested, avoiding extra indirection or path-guarding logic.
- Make checkpoint I/O use the `safetensors` API consistently so the code path is straightforward and reviewable.

### Description
- Import `load_file`/`save_file` from `safetensors.torch` and replace `torch.save`/`torch.load` usages with `save_file`/`load_file` in `gaishi/models/unet/unet_model.py`.
- Remove the explicit `.safetensors` suffix validation checks around best-weight save, early-stop reload, and inference checkpoint load so I/O calls are direct.
- Switch warm-start loading (`trained_model_file`) to `load_file(...)` for consistent safetensors usage.
- Update tests in `tests/models/unet/test_unet_model.py` to use `best.safetensors` and add `safetensors==0.4.5` to `dev-env.yaml` and `build-env.yaml` pip dependencies.

### Testing
- Ran `black gaishi/models/unet/unet_model.py` and formatting completed successfully.
- Attempted `flake8 gaishi/models/unet/unet_model.py` but it could not run in this environment because `flake8` is not available.
- Ran `pytest -q tests/models/unet/test_unet_model.py` but test collection failed due to a missing runtime dependency (`h5py`) in this environment, so unit tests could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70e619c28832cb6d85cb5166f6345)

## Summary by Sourcery

Replace UNet checkpoint I/O to use safetensors consistently and align tests and environments with the new checkpoint format.

Enhancements:
- Standardize UNet training, early-stopping reload, warm-start, and inference to load and save checkpoints via safetensors instead of torch serialization.

Build:
- Add safetensors dependency to build environment configuration.

Tests:
- Update UNet model tests to expect .safetensors checkpoint filenames and behavior.