### PR TITLE
Add `--only-simulation` flag to run simulation without training

### DIFF
--- a/gaishi/parsers/train_parser.py
+++ b/gaishi/parsers/train_parser.py
@@ -32,10 +32,14 @@ def _run_train(args: argparse.Namespace) -> None:
     args : argparse.Namespace
         A namespace object obtained from argparse, containing specified parameters.
     """
+    if not args.only_simulation and args.output is None:
+        raise ValueError("`--output` is required unless `--only-simulation` is set.")
+
     train(
         demes=args.demes,
         config=args.config,
         output=args.output,
+        only_simulation=args.only_simulation,
     )
 
 
@@ -66,7 +70,12 @@ def add_train_parser(subparsers: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--output",
-        required=True,
+        default=None,
         help="Path to the output file.",
+    )
+    parser.add_argument(
+        "--only-simulation",
+        action="store_true",
+        help="Only run simulation and skip model training.",
     )
     parser.set_defaults(runner=_run_train)

--- a/gaishi/train.py
+++ b/gaishi/train.py
@@ -19,6 +19,7 @@
 
 import os
 import yaml
+from typing import Optional
 from gaishi.configs import GlobalConfig
 from gaishi.registries.model_registry import MODEL_REGISTRY
 from gaishi.simulate import simulate_feature_vectors
@@ -29,7 +30,8 @@ from gaishi.utils import UniqueKeyLoader
 def train(
     demes: str,
     config: str,
-    output: str,
+    output: Optional[str] = None,
+    only_simulation: bool = False,
 ) -> None:
     """
     Run simulation and model training from YAML configuration.
@@ -40,9 +42,13 @@ def train(
         Path to the demography (demes) YAML file used for simulation.
     config : str
         Path to the gaishi configuration YAML file.
-    output : str
+    output : str, optional
         Output path or directory passed to the model's `train` method, used
-        to store the trained model.
+        to store the trained model. Required when `only_simulation=False`.
+        Default: None.
+    only_simulation : bool, optional
+        If True, run simulation checks/simulation only and skip model
+        training. Default: False.
     """
     try:
         with open(config, "r") as f:
@@ -69,6 +75,11 @@ def train(
                 demo_model_file=demes,
                 **global_config.simulation.model_dump(),
             )
+
+    if only_simulation:
+        return
+    if output is None:
+        raise ValueError("`output` is required unless `only_simulation=True`.")
 
     model_name = global_config.model.name
     model_params = global_config.model.params

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -493,9 +493,7 @@ def test_infer_unet_rnn_four_channel_outputs_table_binary(
     tab = _read_prob_table(out)
     # same expected as above
     assert tab[("A", 102)] == pytest.approx(_sigmoid_scalar(4.5), rel=1e-6, abs=1e-6)
-    assert tab[("B", 102)] == pytest.approx(
-        _sigmoid_scalar(14.5), rel=1e-6, abs=1e-6
-    )
+    assert tab[("B", 102)] == pytest.approx(_sigmoid_scalar(14.5), rel=1e-6, abs=1e-6)
 
 
 def test_infer_raises_when_add_rnn_true_but_missing_gap_datasets(

--- a/tests/parsers/test_train_parser.py
+++ b/tests/parsers/test_train_parser.py
@@ -20,7 +20,7 @@
 
 import pytest
 import argparse
-from gaishi.parsers.train_parser import add_train_parser
+from gaishi.parsers.train_parser import _run_train, add_train_parser
 
 
 @pytest.fixture
@@ -51,3 +51,31 @@ def test_add_score_parser(parser):
     assert args.demes == "tests/data/ArchIE_3D19.yaml"
     assert args.config == "tests/data/ArchIE.features.yaml"
     assert args.output == "output/results.tsv"
+
+
+def test_train_parser_allows_missing_output_with_only_simulation(parser):
+    args = parser.parse_args(
+        [
+            "train",
+            "--demes",
+            "tests/data/ArchIE_3D19.yaml",
+            "--config",
+            "tests/data/ArchIE.features.yaml",
+            "--only-simulation",
+        ]
+    )
+
+    assert args.only_simulation is True
+    assert args.output is None
+
+
+def test_run_train_requires_output_without_only_simulation():
+    args = argparse.Namespace(
+        demes="tests/data/ArchIE_3D19.yaml",
+        config="tests/data/ArchIE.features.yaml",
+        output=None,
+        only_simulation=False,
+    )
+
+    with pytest.raises(ValueError, match="--output"):
+        _run_train(args)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -61,3 +61,14 @@ def test_train(file_paths, cleanup_output_dir):
     ), "Model coefficient shapes do not match."
     # assert all(abs(a - b) < tolerance for a, b in zip(model.coef_.flatten(), expected_model.coef_.flatten())), "Coefficients do not match within tolerance."
     # assert abs(model.intercept_ - expected_model.intercept_) < tolerance
+
+
+def test_train_only_simulation(file_paths, cleanup_output_dir):
+    train(
+        demes=file_paths["demes"],
+        config=file_paths["config"],
+        output=file_paths["output"],
+        only_simulation=True,
+    )
+
+    assert not os.path.exists(file_paths["output"])


### PR DESCRIPTION
### Motivation
- Provide an option to run simulation steps and skip model fitting so users can generate or verify simulated data without running expensive training.
- Keep the existing `train()` workflow and outputs unchanged when the flag is not used.

### Description
- Add an `only_simulation: bool = False` parameter to `gaishi.train.train` that returns early after simulation checks when set to `True`.
- Expose a new CLI flag `--only-simulation` in `gaishi/parsers/train_parser.py` and pass it into `train(...)`.
- Add `tests/test_train.py::test_train_only_simulation` to assert that no model artifact is written when `only_simulation=True`.

### Testing
- Ran `black gaishi/train.py gaishi/parsers/train_parser.py tests/test_train.py` which completed successfully.
- Attempted `flake8 gaishi/train.py gaishi/parsers/train_parser.py tests/test_train.py` but the environment does not have `flake8` installed so it was not run.
- Attempted `pytest -q tests/test_train.py` but test collection failed with `ModuleNotFoundError: No module named 'joblib'` in this environment, so the new test was not executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89a854acc832c914422490fc2a9e6)

## Summary by Sourcery

Add a configurable option to run only the simulation phase without training and wire it through the CLI and tests.

New Features:
- Add an only_simulation option to the train workflow to skip model training after simulations.
- Expose a --only-simulation CLI flag to control simulation-only runs.

Tests:
- Add a test ensuring that no model output is written when running in simulation-only mode.