### PR TITLE
update model name and output device name into training log file

### DIFF
--- a/examples/configs/unet.training.yaml
+++ b/examples/configs/unet.training.yaml
@@ -19,7 +19,7 @@ simulation:
   nfeature: 100
 
 model:
-  name: "unet"
+  name: "unet++"
   params:
     add_channels: False,
     n_classes: 1,

--- a/gaishi/configs/model_config.py
+++ b/gaishi/configs/model_config.py
@@ -23,5 +23,5 @@ from pydantic import BaseModel, Field
 
 
 class ModelConfig(BaseModel):
-    name: Literal["logistic_regression", "extra_trees_classifier", "unet"]
+    name: Literal["logistic_regression", "extra_trees_classifier", "unet++"]
     params: dict[str, Any] = Field(default_factory=dict)

--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -35,7 +35,7 @@ from gaishi.registries.model_registry import MODEL_REGISTRY
 from gaishi.models.unet.dataloader_h5 import build_dataloaders_from_h5
 
 
-@MODEL_REGISTRY.register("unet")
+@MODEL_REGISTRY.register("unet++")
 class UNetModel(MlModel):
     """
     UNet-based model wrapper for training and inference on HDF5 datasets.
@@ -170,6 +170,8 @@ class UNetModel(MlModel):
 
         training_log_file = open(os.path.join(output_dir, "training.log"), "w")
         validation_log_file = open(os.path.join(output_dir, "validation.log"), "w")
+        training_log_file.write(f"device = {dev}\n")
+        training_log_file.flush()
 
         # Read shapes from unified schema
         with h5py.File(data, "r") as f:

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -182,9 +182,12 @@ def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch) -> None:
     assert DummyUNetPlusPlus.last_init["input_channels"] == 2
     assert DummyUNetPlusPlusRNN.last_init is None
 
-    assert (model_dir / "training.log").exists()
+    training_log = model_dir / "training.log"
+    assert training_log.exists()
     assert (model_dir / "validation.log").exists()
     assert (model_dir / "best.pth").exists()
+
+    assert "device = cpu" in training_log.read_text()
 
 
 def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch) -> None:
@@ -493,9 +496,7 @@ def test_infer_unet_rnn_four_channel_outputs_table_binary(
     tab = _read_prob_table(out)
     # same expected as above
     assert tab[("A", 102)] == pytest.approx(_sigmoid_scalar(4.5), rel=1e-6, abs=1e-6)
-    assert tab[("B", 102)] == pytest.approx(
-        _sigmoid_scalar(14.5), rel=1e-6, abs=1e-6
-    )
+    assert tab[("B", 102)] == pytest.approx(_sigmoid_scalar(14.5), rel=1e-6, abs=1e-6)
 
 
 def test_infer_raises_when_add_rnn_true_but_missing_gap_datasets(


### PR DESCRIPTION
## Summary by Sourcery

Log training device information to the UNet model training log and update the UNet model identifier to use the "unet++" name consistently across code and configuration.

New Features:
- Record the output device used for training in the UNet training.log file.

Enhancements:
- Change the registered name of the UNet model to "unet++" and align example configuration and model config validation with this identifier.

Tests:
- Extend UNet training tests to assert that the training log includes the device information and tidy an inference test assertion formatting.