### PR TITLE
Add `num_workers` option to UNetModel.train and pass to dataloader builder

### DIFF
--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -66,6 +66,7 @@ class UNetModel(MlModel):
         val_prop: float = 0.05,
         seed: int = None,
         device: str = None,
+        num_workers: int = 0,
         **kwargs,
     ) -> None:
         """
@@ -151,6 +152,9 @@ class UNetModel(MlModel):
             Default: None.
         device : Optional[str].
             Force device string like ``"cuda:0"`` or ``"cpu"``. Default: None.
+        num_workers : int, optional
+            Number of DataLoader worker processes used for training/validation
+            loaders. Default: 0.
 
         Raises
         ------
@@ -158,6 +162,8 @@ class UNetModel(MlModel):
             If the HDF5 file contains no replicates.
         ValueError
             If training labels contain no positive class.
+        ValueError
+            If ``num_workers`` is not a non-negative integer.
         KeyError
             If required datasets are missing from the HDF5 file.
         """
@@ -182,6 +188,9 @@ class UNetModel(MlModel):
         if num_genotype_matrices == 0:
             raise ValueError(f"No genotype matrices found in HDF5 file: {data}")
 
+        if not isinstance(num_workers, int) or num_workers < 0:
+            raise ValueError("`num_workers` must be a non-negative integer.")
+
         input_channels = 4 if add_rnn else 2
 
         train_loader, val_loader, train_indices, val_indices = (
@@ -190,7 +199,7 @@ class UNetModel(MlModel):
                 channels=input_channels,
                 batch_size=batch_size,
                 val_prop=val_prop,
-                num_workers=0,
+                num_workers=num_workers,
                 pin_memory=torch.cuda.is_available(),
                 seed=seed,
                 train_label_smooth=True,

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -448,6 +448,28 @@ def _read_prob_table(path: str) -> dict[tuple[str, int], list[float]]:
     return out
 
 
+
+
+def test_train_raises_when_num_workers_is_negative(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=10, N=2, L=7, with_gaps=True)
+    model_path = tmp_path / "model_out_neg_workers" / "best.safetensors"
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        unet_mod.UNetModel.train(
+            data=training_data,
+            output=str(model_path),
+            add_rnn=False,
+            batch_size=2,
+            n_epochs=1,
+            n_early=0,
+            min_delta=0.0,
+            val_prop=0.2,
+            seed=0,
+            num_workers=-1,
+        )
 def test_infer_unetplusplus_two_channel_outputs_table_binary(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Allow configuration of the number of worker processes used by DataLoaders instead of using a hardcoded `0`, enabling better control of I/O and parallelism when training on different systems.

### Description
- Add a `num_workers: int = 0` parameter to `UNetModel.train` (signature and docstring) and forward it to `build_dataloaders_from_h5` in place of the previous hardcoded `0`.

### Testing
- Ran the project's automated test suite with `pytest -q` and confirmed the tests covering the training dataloader and related modules passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0a7fc154832c948a98fdc4dedab8)

## Summary by Sourcery

New Features:
- Add a num_workers parameter to UNetModel.train to control DataLoader worker processes during training and validation.