### PR TITLE
Log explicit CUDA device in UNetModel training logs

### DIFF
--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -174,10 +174,15 @@ class UNetModel(MlModel):
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
         dev = torch.device(device)
+        log_dev = (
+            torch.device(f"cuda:{torch.cuda.current_device()}")
+            if dev.type == "cuda" and dev.index is None
+            else dev
+        )
 
         training_log_file = open(os.path.join(output_dir, "training.log"), "w")
         validation_log_file = open(os.path.join(output_dir, "validation.log"), "w")
-        training_log_file.write(f"device = {dev}\n")
+        training_log_file.write(f"device = {log_dev}\n")
         training_log_file.flush()
 
         # Read shapes from unified schema


### PR DESCRIPTION
### Motivation
- Ensure `training.log` records the explicit CUDA device when `device` was set to `"cuda"` without an index so logs reflect the actual runtime device.

### Description
- Add `log_dev` which resolves to `torch.device(f"cuda:{torch.cuda.current_device()}")` when `dev.type == "cuda"` and `dev.index is None`, and use `log_dev` when writing the device line to `training.log`.

### Testing
- Ran the project test suite with `pytest` against the modified module and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc0dea050832c912090ab3c6ca0da)

## Summary by Sourcery

Bug Fixes:
- Ensure training logs record the concrete CUDA device index when the model is initialized with an unindexed 'cuda' device string instead of leaving it ambiguous.