### PR TITLE
Expose DataLoader worker tuning (persistent_workers, prefetch_factor) and forward from UNet training

### DIFF
--- a/gaishi/models/unet/dataloader_h5.py
+++ b/gaishi/models/unet/dataloader_h5.py
@@ -245,6 +245,8 @@ def build_dataloaders_from_h5(
     train_label_noise: float = 0.01,
     train_drop_last: bool = True,
     val_drop_last: bool = False,
+    persistent_workers: bool = False,
+    prefetch_factor: int = 2,
 ) -> Tuple[DataLoader, DataLoader, List[int], List[int]]:
     """
     Construct train/validation DataLoaders from an HDF5 file via `torch.random_split`.
@@ -282,6 +284,12 @@ def build_dataloaders_from_h5(
         Whether to drop the final incomplete batch in the training DataLoader.
     val_drop_last : bool, default=False
         Whether to drop the final incomplete batch in the validation DataLoader.
+    persistent_workers : bool, default=False
+        Whether to keep DataLoader worker processes alive across epochs.
+        Applied only when ``num_workers > 0``.
+    prefetch_factor : int, default=2
+        Number of batches prefetched by each worker. Must be a positive
+        integer. Applied only when ``num_workers > 0``.
 
     Returns
     -------
@@ -306,6 +314,10 @@ def build_dataloaders_from_h5(
       shuffling in tests.
     - ``drop_last`` behavior is configurable per loader via ``train_drop_last`` and
       ``val_drop_last``.
+    - ``persistent_workers`` and ``prefetch_factor`` are only passed when
+      ``num_workers > 0``. This avoids invalid DataLoader configurations in
+      single-process loading mode and allows tuning worker startup/prefetch
+      overhead for potential throughput gains in multi-worker runs.
     """
     # Base dataset over all replicates/windows
     base_ds = H5Dataset(
@@ -332,6 +344,19 @@ def build_dataloaders_from_h5(
 
     train_ds, val_ds = random_split(base_ds, [n_train, n_val], generator=g)
 
+    if num_workers == 0 and persistent_workers:
+        persistent_workers = False
+
+    loader_worker_kwargs = {}
+    if num_workers > 0:
+        if not isinstance(prefetch_factor, int) or prefetch_factor <= 0:
+            raise ValueError("`prefetch_factor` must be a positive integer.")
+
+        loader_worker_kwargs = {
+            "persistent_workers": persistent_workers,
+            "prefetch_factor": prefetch_factor,
+        }
+
     train_loader = DataLoader(
         train_ds,
         batch_size=batch_size,
@@ -344,6 +369,7 @@ def build_dataloaders_from_h5(
             label_noise=train_label_noise,
             rng=train_rng,
         ),
+        **loader_worker_kwargs,
     )
 
     val_loader = DataLoader(
@@ -357,6 +383,7 @@ def build_dataloaders_from_h5(
             label_smooth=False,
             rng=val_rng,
         ),
+        **loader_worker_kwargs,
     )
 
     return train_loader, val_loader, train_ds.indices, val_ds.indices

--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -68,6 +68,8 @@ class UNetModel(MlModel):
         num_workers: int = 0,
         train_drop_last: Optional[bool] = None,
         val_drop_last: Optional[bool] = None,
+        persistent_workers: Optional[bool] = None,
+        prefetch_factor: Optional[int] = None,
         use_amp: bool = False,
         **kwargs,
     ) -> None:
@@ -163,6 +165,15 @@ class UNetModel(MlModel):
         val_drop_last : Optional[bool], optional
             Whether to drop the final incomplete batch in the validation DataLoader.
             If None, use ``build_dataloaders_from_h5`` default. Default: None.
+        persistent_workers : Optional[bool], optional
+            Keep DataLoader worker processes alive across epochs to reduce worker
+            startup overhead. Effective only when ``num_workers > 0``. When None,
+            defer to ``build_dataloaders_from_h5`` defaults. Default: None.
+        prefetch_factor : Optional[int], optional
+            Number of batches prefetched by each DataLoader worker. Must be a
+            positive integer when set. Effective only when ``num_workers > 0``.
+            When None, defer to ``build_dataloaders_from_h5`` defaults.
+            Default: None.
         use_amp : bool, optional
             Enable CUDA AMP training/inference execution path. When True and CUDA is
             used, forward/loss runs under autocast and backpropagation uses
@@ -225,6 +236,10 @@ class UNetModel(MlModel):
             dataloader_kwargs["train_drop_last"] = train_drop_last
         if val_drop_last is not None:
             dataloader_kwargs["val_drop_last"] = val_drop_last
+        if persistent_workers is not None:
+            dataloader_kwargs["persistent_workers"] = persistent_workers
+        if prefetch_factor is not None:
+            dataloader_kwargs["prefetch_factor"] = prefetch_factor
 
         train_loader, val_loader, train_indices, val_indices = (
             build_dataloaders_from_h5(**dataloader_kwargs)

--- a/tests/models/unet/test_dataloader_h5.py
+++ b/tests/models/unet/test_dataloader_h5.py
@@ -311,3 +311,84 @@ def test_build_dataloaders_from_h5_drop_last_flags(h5_with_labels):
 
     assert len(train_loader) == (n_train + batch_size - 1) // batch_size
     assert len(val_loader) == n_val // batch_size
+
+
+def test_build_dataloaders_num_workers_zero_ignores_worker_perf_kwargs(h5_with_labels):
+    path, _ = h5_with_labels
+
+    train_loader, val_loader, _, _ = build_dataloaders_from_h5(
+        h5_file=path,
+        channels=2,
+        batch_size=2,
+        num_workers=0,
+        persistent_workers=True,
+        prefetch_factor=4,
+    )
+
+    assert train_loader.num_workers == 0
+    assert val_loader.num_workers == 0
+
+
+def test_build_dataloaders_num_workers_gt_zero_forwards_worker_perf_kwargs(
+    h5_with_labels, monkeypatch
+):
+    path, _ = h5_with_labels
+    captured = []
+
+    real_dataloader = __import__(
+        "gaishi.models.unet.dataloader_h5", fromlist=["DataLoader"]
+    ).DataLoader
+
+    def _capture_dataloader(*args, **kwargs):
+        captured.append(kwargs.copy())
+        kwargs.pop("persistent_workers", None)
+        kwargs.pop("prefetch_factor", None)
+        kwargs["num_workers"] = 0
+        return real_dataloader(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "gaishi.models.unet.dataloader_h5.DataLoader", _capture_dataloader
+    )
+
+    build_dataloaders_from_h5(
+        h5_file=path,
+        channels=2,
+        batch_size=2,
+        num_workers=1,
+        persistent_workers=True,
+        prefetch_factor=3,
+    )
+
+    assert len(captured) == 2
+    assert all(kwargs["persistent_workers"] is True for kwargs in captured)
+    assert all(kwargs["prefetch_factor"] == 3 for kwargs in captured)
+
+
+def test_build_dataloaders_invalid_prefetch_factor_raises(h5_with_labels):
+    path, _ = h5_with_labels
+
+    with pytest.raises(ValueError, match="prefetch_factor"):
+        build_dataloaders_from_h5(
+            h5_file=path,
+            channels=2,
+            batch_size=2,
+            num_workers=1,
+            prefetch_factor=0,
+        )
+
+
+def test_build_dataloaders_num_workers_zero_ignores_invalid_prefetch_factor(
+    h5_with_labels,
+):
+    path, _ = h5_with_labels
+
+    train_loader, val_loader, _, _ = build_dataloaders_from_h5(
+        h5_file=path,
+        channels=2,
+        batch_size=2,
+        num_workers=0,
+        prefetch_factor=0,
+    )
+
+    assert train_loader.num_workers == 0
+    assert val_loader.num_workers == 0

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -760,3 +760,77 @@ def test_binary_batch_accuracy_from_logits_zero_logit_is_positive() -> None:
     accuracy = unet_mod._binary_batch_accuracy_from_logits(logits, labels)
 
     assert accuracy == 1.0
+
+
+def test_train_passes_worker_perf_kwargs_to_dataloader(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=10, N=2, L=7, with_gaps=True)
+    model_path = tmp_path / "model_out_workers_kwargs" / "best.safetensors"
+
+    captured = {}
+
+    def _fake_build_dataloaders_from_h5(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop_after_capture")
+
+    monkeypatch.setattr(
+        unet_mod, "build_dataloaders_from_h5", _fake_build_dataloaders_from_h5
+    )
+
+    with pytest.raises(RuntimeError, match="stop_after_capture"):
+        unet_mod.UNetModel.train(
+            data=training_data,
+            output=str(model_path),
+            add_rnn=False,
+            batch_size=2,
+            n_epochs=1,
+            n_early=0,
+            min_delta=0.0,
+            val_prop=0.2,
+            seed=0,
+            num_workers=0,
+            persistent_workers=True,
+            prefetch_factor=5,
+        )
+
+    assert captured["persistent_workers"] is True
+    assert captured["prefetch_factor"] == 5
+
+
+def test_train_uses_dataloader_worker_perf_defaults_when_none(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=10, N=2, L=7, with_gaps=True)
+    model_path = tmp_path / "model_out_workers_defaults" / "best.safetensors"
+
+    captured = {}
+
+    def _fake_build_dataloaders_from_h5(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop_after_capture")
+
+    monkeypatch.setattr(
+        unet_mod, "build_dataloaders_from_h5", _fake_build_dataloaders_from_h5
+    )
+
+    with pytest.raises(RuntimeError, match="stop_after_capture"):
+        unet_mod.UNetModel.train(
+            data=training_data,
+            output=str(model_path),
+            add_rnn=False,
+            batch_size=2,
+            n_epochs=1,
+            n_early=0,
+            min_delta=0.0,
+            val_prop=0.2,
+            seed=0,
+            num_workers=0,
+        )
+
+    assert "persistent_workers" not in captured
+    assert "prefetch_factor" not in captured


### PR DESCRIPTION
### Motivation

- Provide knobs to tune `torch.utils.data.DataLoader` worker performance (`persistent_workers` and `prefetch_factor`) for multi-worker data loading and avoid invalid configurations when `num_workers == 0`.
- Allow the UNet training entrypoint to opt into these worker-performance options so callers can control worker startup/prefetch overhead.

### Description

- Extend `build_dataloaders_from_h5` with new parameters `persistent_workers: bool = False` and `prefetch_factor: int = 2`, validate that `prefetch_factor` is a positive integer, and coerce/ignore `persistent_workers` when `num_workers == 0`.
- Only inject `persistent_workers` and `prefetch_factor` into the `DataLoader` constructor when `num_workers > 0` to avoid invalid single-process loader arguments.
- Add optional `persistent_workers` and `prefetch_factor` parameters to `UNetModel.train` and forward them into the dataloader construction when provided, with updated docstrings describing the behavior.
- Add unit tests covering zero-worker behavior, correct forwarding when `num_workers > 0`, validation of `prefetch_factor`, and that `UNetModel.train` passes or omits these kwargs appropriately.

### Testing

- Ran `pytest` for the modified test modules and the new tests `test_build_dataloaders_num_workers_zero_ignores_worker_perf_kwargs`, `test_build_dataloaders_num_workers_gt_zero_forwards_worker_perf_kwargs`, and `test_build_dataloaders_invalid_prefetch_factor_raises` in `tests/models/unet/test_dataloader_h5.py`, which passed.
- Ran `pytest` for the new `UNetModel` tests `test_train_passes_worker_perf_kwargs_to_dataloader` and `test_train_uses_dataloader_worker_perf_defaults_when_none` in `tests/models/unet/test_unet_model.py`, which passed.
- Existing tests exercising loader shapes and `drop_last` semantics were also executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6ba24800832c805963c39a06dc19)

## Summary by Sourcery

Expose configurable DataLoader worker performance options and wire them through the UNet training API while ensuring safe defaults for single-process loading.

New Features:
- Add `persistent_workers` and `prefetch_factor` options to HDF5-based DataLoader construction for tuning multi-worker data loading behavior.
- Allow `UNetModel.train` callers to optionally control DataLoader worker persistence and prefetching via new parameters that forward into dataloader creation.

Bug Fixes:
- Prevent invalid DataLoader configurations by only applying worker persistence and prefetch settings when `num_workers > 0` and validating that `prefetch_factor` is a positive integer.

Tests:
- Add tests covering zero-worker behavior, correct propagation of worker performance options, and validation of `prefetch_factor` in `build_dataloaders_from_h5`.
- Add tests ensuring `UNetModel.train` forwards worker performance options when provided and relies on dataloader defaults when they are omitted.