### PR TITLE
Rename UNet config param to `add_rnn`, bump copyright years, and clean up docs/types

### DIFF
--- a/examples/configs/unet.training.yaml
+++ b/examples/configs/unet.training.yaml
@@ -21,7 +21,7 @@ simulation:
 model:
   name: "unet++"
   params:
-    add_channels: False,
+    add_rnn: False,
     n_classes: 1,
     learning_rate: 0.001,
     batch_size: 32,

--- a/gaishi/__init__.py
+++ b/gaishi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,9 +17,7 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 from importlib.metadata import version, PackageNotFoundError
-
 
 try:
     __version__ = version("gaishi")

--- a/gaishi/__main__.py
+++ b/gaishi/__main__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import argparse
 import gaishi.models

--- a/gaishi/configs/__init__.py
+++ b/gaishi/configs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .feature_config import FeatureConfig  # noqa: F401
 from .model_config import ModelConfig  # noqa: F401

--- a/gaishi/configs/feature_config.py
+++ b/gaishi/configs/feature_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from typing import Dict, Union, Set
 from pydantic import RootModel, field_validator

--- a/gaishi/configs/global_config.py
+++ b/gaishi/configs/global_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Annotated, Union
 from gaishi.configs import ModelConfig
@@ -25,7 +24,6 @@ from gaishi.configs import FeatureVectorSimulationConfig
 from gaishi.configs import GenotypeMatrixSimulationConfig
 from gaishi.configs import FeatureVectorPreprocessConfig
 from gaishi.configs import GenotypeMatrixPreprocessConfig
-
 
 SimulationConfigUnion = Annotated[
     Union[FeatureVectorSimulationConfig, GenotypeMatrixSimulationConfig],

--- a/gaishi/configs/model_config.py
+++ b/gaishi/configs/model_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from typing import Any, Literal
 from pydantic import BaseModel, Field

--- a/gaishi/configs/preprocess_config.py
+++ b/gaishi/configs/preprocess_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from pathlib import Path
 from typing import Optional, Literal

--- a/gaishi/configs/simulation_config.py
+++ b/gaishi/configs/simulation_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from pathlib import Path
 from pydantic import BaseModel, ConfigDict

--- a/gaishi/generators/__init__.py
+++ b/gaishi/generators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_generator import GenericGenerator  # noqa: F401
 from .random_number_generator import RandomNumberGenerator  # noqa: F401

--- a/gaishi/generators/generic_generator.py
+++ b/gaishi/generators/generic_generator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 

--- a/gaishi/generators/polymorphism_data_generator.py
+++ b/gaishi/generators/polymorphism_data_generator.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from gaishi.utils import read_data, split_genome

--- a/gaishi/generators/random_number_generator.py
+++ b/gaishi/generators/random_number_generator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from gaishi.generators import GenericGenerator

--- a/gaishi/generators/window_data_generator.py
+++ b/gaishi/generators/window_data_generator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from gaishi.utils import read_data, split_genome

--- a/gaishi/infer.py
+++ b/gaishi/infer.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import yaml
 from gaishi.configs import GlobalConfig

--- a/gaishi/labelers/__init__.py
+++ b/gaishi/labelers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_labeler import GenericLabeler  # noqa: F401
 from .binary_allele_labeler import BinaryAlleleLabeler  # noqa: F401

--- a/gaishi/labelers/binary_allele_labeler.py
+++ b/gaishi/labelers/binary_allele_labeler.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import allel
 import numpy as np

--- a/gaishi/labelers/binary_window_labeler.py
+++ b/gaishi/labelers/binary_window_labeler.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os
 import numpy as np

--- a/gaishi/labelers/generic_labeler.py
+++ b/gaishi/labelers/generic_labeler.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 

--- a/gaishi/models/__init__.py
+++ b/gaishi/models/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .ml_model import MlModel  # noqa: F401
 from .lr_model import LrModel  # noqa: F401

--- a/gaishi/models/etc_model.py
+++ b/gaishi/models/etc_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,14 +17,12 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import inspect, joblib, os
 import pandas as pd
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.preprocessing import StandardScaler
 from gaishi.models import MlModel
 from gaishi.registries.model_registry import MODEL_REGISTRY
-
 
 pd.options.mode.chained_assignment = None
 
@@ -109,7 +107,7 @@ class EtcModel(MlModel):
         Any keyword arguments in `model_params` are forwarded to the underlying
         :class:`sklearn.ensemble.ExtraTreesClassifier` or used to control
         optional preprocessing. If an `is_scaled` flag is provided and set to
-        True, a scaler object is loaded from ``<model>.scaler`` and applied to
+        True, a scaler object is loaded from `<model>.scaler` and applied to
         the feature matrix before inference.
 
         Parameters
@@ -121,8 +119,8 @@ class EtcModel(MlModel):
             prediction.
         model : str
             Path to the saved trained model (e.g. a joblib pickle). If
-            ``is_scaled=True`` is passed via `model_params`, the method will
-            also look for a corresponding scaler file at ``<model>.scaler`` and
+            `is_scaled=True` is passed via `model_params`, the method will
+            also look for a corresponding scaler file at `<model>.scaler` and
             apply it to the features.
         output : str
             Path where the inference output (e.g. predicted labels or

--- a/gaishi/models/lr_model.py
+++ b/gaishi/models/lr_model.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,14 +17,12 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import inspect, joblib, os
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import StandardScaler
 from gaishi.models import MlModel
 from gaishi.registries.model_registry import MODEL_REGISTRY
-
 
 pd.options.mode.chained_assignment = None
 
@@ -102,7 +101,7 @@ class LrModel(MlModel):
         Any keyword arguments in `model_params` are forwarded to the underlying
         :class:`sklearn.linear_model.LogisticRegression` or used to control
         optional preprocessing. If an `is_scaled` flag is provided and set to
-        True, a scaler object is loaded from ``<model>.scaler`` and applied to
+        True, a scaler object is loaded from `<model>.scaler` and applied to
         the feature matrix before inference.
 
         Parameters

--- a/gaishi/models/ml_model.py
+++ b/gaishi/models/ml_model.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 import pandas as pd

--- a/gaishi/models/unet/__init__.py
+++ b/gaishi/models/unet/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,6 +16,5 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .unet_model import UNetModel

--- a/gaishi/models/unet/dataloader_h5.py
+++ b/gaishi/models/unet/dataloader_h5.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from __future__ import annotations
 
@@ -62,19 +61,19 @@ class H5Dataset(Dataset):
     ----------
     h5_file : str
         Path to the HDF5 file.
-    indices : Optional[Sequence[int]], default=None
+    indices : Optional[Sequence[int]], optional
         Subset of replicate indices to expose. If None, the dataset spans
-        all replicates `0..R-1`.
-    channels : int, default=4
-        Number of input channels to return. Must be 2 or 4.
+        all replicates `0..R-1`. Default: None.
+    channels : int, optional
+        Number of input channels to return. Must be 2 or 4. Default: 4.
 
         - If 2: returns `[Ref_genotype, Tgt_genotype]`
         - If 4: returns `[Ref_genotype, Tgt_genotype, Gap_to_prev, Gap_to_next]`
-    require_labels : bool, default=True
+    require_labels : bool, optional
         If True, raises a KeyError when `/targets/Label` is absent. If False,
-        returns `y=None` when labels are missing.
-    x_dtype : numpy.dtype, default=numpy.int32
-        Output dtype for `x` after stacking.
+        returns `y=None` when labels are missing. Default: True.
+    x_dtype : numpy.dtype, optional
+        Output dtype for `x` after stacking. Default: `numpy.int32`.
 
     Returns
     -------
@@ -176,13 +175,13 @@ def make_h5_collate_fn(
 
     Parameters
     ----------
-    label_smooth : bool, default=False
-        Whether to apply label smoothing/noise to the stacked labels.
-    label_noise : float, default=0.01
-        Maximum noise amplitude used when `label_smooth=True`.
-    rng : Optional[numpy.random.Generator], default=None
+    label_smooth : bool, optional
+        Whether to apply label smoothing/noise to the stacked labels. Default: False.
+    label_noise : float, optional
+        Maximum noise amplitude used when `label_smooth=True`. Default: 0.01.
+    rng : Optional[numpy.random.Generator], optional
         RNG used to sample smoothing noise. If None, a new default generator
-        is created.
+        is created. Default: None.
 
     Returns
     -------
@@ -266,39 +265,39 @@ def build_dataloaders_from_h5(
         Number of input channels (2 or 4). Passed to `H5Dataset`.
     batch_size : int
         Batch size for both loaders.
-    val_prop : float, default=0.05
+    val_prop : float, optional
         Proportion of replicates assigned to validation.
-        The validation size is `int(n_total * val_prop)`.
-    num_workers : int, default=0
-        Number of DataLoader worker processes.
-    pin_memory : bool, default=True
-        Whether to enable pinned memory in the DataLoaders.
-    seed : Optional[int], default=None
+        The validation size is `int(n_total * val_prop)`. Default: 0.05.
+    num_workers : int, optional
+        Number of DataLoader worker processes. Default: 0.
+    pin_memory : bool, optional
+        Whether to enable pinned memory in the DataLoaders. Default: True.
+    seed : int, optional
         Seed for the deterministic split (PyTorch generator). Also used to seed
-        NumPy RNGs for label smoothing (`seed` for train, `seed + 1` for val).
-    train_label_smooth : bool, default=True
-        Whether to apply label smoothing/noise in the training collate function.
-    train_label_noise : float, default=0.01
-        Maximum smoothing noise amplitude used when `train_label_smooth=True`.
-    train_drop_last : bool, default=True
-        Whether to drop the final incomplete batch in the training DataLoader.
-    val_drop_last : bool, default=False
-        Whether to drop the final incomplete batch in the validation DataLoader.
-    persistent_workers : bool, default=False
+        NumPy RNGs for label smoothing (`seed` for train, `seed + 1` for val). Default: 0.
+    train_label_smooth : bool, optional
+        Whether to apply label smoothing/noise in the training collate function. Default: True.
+    train_label_noise : float, optional
+        Maximum smoothing noise amplitude used when `train_label_smooth=True`. Default: 0.01.
+    train_drop_last : bool, optional
+        Whether to drop the final incomplete batch in the training DataLoader. Default: True.
+    val_drop_last : bool, optional
+        Whether to drop the final incomplete batch in the validation DataLoader. Default: False.
+    persistent_workers : bool, optional
         Whether to keep DataLoader worker processes alive across epochs.
-        Applied only when ``num_workers > 0``.
-    prefetch_factor : int, default=2
+        Applied only when `num_workers > 0`. Default: False.
+    prefetch_factor : int, optional
         Number of batches prefetched by each worker. Must be a positive
-        integer. Applied only when ``num_workers > 0``.
+        integer. Applied only when `num_workers > 0`. Default: 2.
 
     Returns
     -------
     train_loader : torch.utils.data.DataLoader
         Training loader built from the training subset. Uses `shuffle=True` and
-        configurable `drop_last` via ``train_drop_last``.
+        configurable `drop_last` via `train_drop_last`.
     val_loader : torch.utils.data.DataLoader
         Validation loader built from the validation subset. Uses `shuffle=False`
-        and configurable `drop_last` via ``val_drop_last``.
+        and configurable `drop_last` via `val_drop_last`.
     train_indices : list[int]
         Replicate indices (into the base dataset) assigned to training.
         This is `train_subset.indices` from the `Subset` returned by `random_split`.
@@ -312,10 +311,10 @@ def build_dataloaders_from_h5(
     - Shuffling order within the training loader is controlled by PyTorch; set
       `torch.manual_seed(...)` externally if you need deterministic per-epoch
       shuffling in tests.
-    - ``drop_last`` behavior is configurable per loader via ``train_drop_last`` and
-      ``val_drop_last``.
-    - ``persistent_workers`` and ``prefetch_factor`` are only passed when
-      ``num_workers > 0``. This avoids invalid DataLoader configurations in
+    - `drop_last` behavior is configurable per loader via `train_drop_last` and
+      `val_drop_last`.
+    - `persistent_workers` and `prefetch_factor` are only passed when
+      `num_workers > 0`. This avoids invalid DataLoader configurations in
       single-process loading mode and allows tuning worker startup/prefetch
       overhead for potential throughput gains in multi-worker runs.
     """

--- a/gaishi/models/unet/layers/__init__.py
+++ b/gaishi/models/unet/layers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .residual_concat_block import ResidualConcatBlock
 from .unet_plus_plus import UNetPlusPlus

--- a/gaishi/models/unet/layers/residual_concat_block.py
+++ b/gaishi/models/unet/layers/residual_concat_block.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import torch
 import torch.nn as nn
 
@@ -26,7 +25,7 @@ class ResidualConcatBlock(nn.Module):
     """
     Convolutional block with residual accumulation and channel-wise concatenation.
 
-    This block applies a stack of ``n_layers`` 2D convolutions. Each convolution is followed
+    This block applies a stack of `n_layers` 2D convolutions. Each convolution is followed
     by instance normalization and spatial dropout. Starting from the second layer, a residual
     connection is applied within the block by adding the current layer output to the previous
     layer output. Finally, outputs from all layers are concatenated along the channel dimension
@@ -39,24 +38,24 @@ class ResidualConcatBlock(nn.Module):
     out_channels : int
         Number of output channels of each convolutional layer inside the block.
     k : int
-        Convolution kernel size (square kernel ``k x k``). Default: 3.
+        Convolution kernel size (square kernel `k x k`). Default: 3.
 
     Returns
     -------
     torch.Tensor
-        Output tensor of shape ``(B, out_channels * n_layers, H, W)``.
+        Output tensor of shape `(B, out_channels * n_layers, H, W)`.
 
     Raises
     ------
     ValueError
-        If ``k < 1``.
+        If `k < 1`.
     ValueError
-        If ``k`` is even.
+        If `k` is even.
 
     Notes
     -----
-    - The output channel dimension equals ``out_channels * n_layers`` due to concatenation.
-    - Padding is set to keep spatial resolution unchanged for odd ``k``.
+    - The output channel dimension equals `out_channels * n_layers` due to concatenation.
+    - Padding is set to keep spatial resolution unchanged for odd `k`.
     - This block is often used in encoder-decoder architectures where the channel expansion
       from concatenation is expected downstream.
 
@@ -115,12 +114,12 @@ class ResidualConcatBlock(nn.Module):
         Parameters
         ----------
         x : torch.Tensor
-            Input tensor of shape ``(B, C_in, H, W)``.
+            Input tensor of shape `(B, C_in, H, W)`.
 
         Returns
         -------
         torch.Tensor
-            Output tensor of shape ``(B, out_channels * n_layers, H, W)``.
+            Output tensor of shape `(B, out_channels * n_layers, H, W)`.
         """
         layer_outputs = [self.post_layers[0](self.conv_layers[0](x))]
 

--- a/gaishi/models/unet/layers/unet_plus_plus.py
+++ b/gaishi/models/unet/layers/unet_plus_plus.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import torch
 import torch.nn as nn
 from gaishi.models.unet.layers import ResidualConcatBlock
@@ -32,8 +31,8 @@ class UNetPlusPlus(nn.Module):
     from earlier nodes at the same resolution are concatenated with an upsampled feature map
     from the next deeper resolution, then processed by a convolutional block.
 
-    The network uses ``ResidualConcatBlock`` at each grid node. With the default block setting
-    (``n_layers=2``), each node produces the expected channel dimension for the predefined
+    The network uses `ResidualConcatBlock` at each grid node. With the default block setting
+    (`n_layers=2`), each node produces the expected channel dimension for the predefined
     channel schedule.
 
     Parameters
@@ -46,15 +45,15 @@ class UNetPlusPlus(nn.Module):
     Returns
     -------
     torch.Tensor
-        Model output logits ``(B, num_classes, H, W)``.
+        Model output logits `(B, num_classes, H, W)`.
 
     Notes
     -----
     - Downsampling is performed by max pooling with stride 2.
     - Upsampling is performed by bilinear interpolation with scale factor 2.
-    - The nested structure is expressed by nodes of the form ``x_{i,j}``, where ``i`` is
-      the depth (downsampling level) and ``j`` is the decoder stage at the same resolution.
-      The top row nodes ``x_{0,1}`` ... ``x_{0,4}`` progressively concatenate earlier top-row
+    - The nested structure is expressed by nodes of the form `x_{i,j}`, where `i` is
+      the depth (downsampling level) and `j` is the decoder stage at the same resolution.
+      The top row nodes `x_{0,1}` ... `x_{0,4}` progressively concatenate earlier top-row
       outputs, forming dense skip connections.
 
     Attributes
@@ -64,7 +63,7 @@ class UNetPlusPlus(nn.Module):
     upsample : torch.nn.Module
         Bilinear upsampling layer used for upsampling.
     output_head : torch.nn.Conv2d
-        Final ``1x1`` convolution mapping features to logits.
+        Final `1x1` convolution mapping features to logits.
     """
 
     def __init__(self, num_classes: int, input_channels: int):
@@ -126,12 +125,12 @@ class UNetPlusPlus(nn.Module):
         Parameters
         ----------
         x : torch.Tensor
-            Input tensor of shape ``(B, input_channels, H, W)``.
+            Input tensor of shape `(B, input_channels, H, W)`.
 
         Returns
         -------
         torch.Tensor
-            Output logits ``(B, num_classes, H, W)``.
+            Output logits `(B, num_classes, H, W)`.
         """
         feat00 = self.node00(x)
         feat10 = self.node10(self.downsample(feat00))

--- a/gaishi/models/unet/layers/unet_plus_plus_rnn.py
+++ b/gaishi/models/unet/layers/unet_plus_plus_rnn.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import torch
 import torch.nn as nn
 from gaishi.models.unet.layers import UNetPlusPlus
@@ -34,15 +33,15 @@ class UNetPlusPlusRNN(nn.Module):
       the width dimension.
 
     The fusion treats each row as a sequence:
-    - Sequence length is ``W`` (width).
-    - GRU batch dimension is ``B * H`` (batch times height).
+    - Sequence length is `W` (width).
+    - GRU batch dimension is `B * H` (batch times height).
 
     Parameters
     ----------
     num_classes : int
         Number of classes.
     polymorphisms : int
-        Expected width ``W`` of the input. The final MLP maps a length-``W`` vector to length-``W``.
+        Expected width `W` of the input. The final MLP maps a length-`W` vector to length-`W`.
         Default: 128.
     hidden_dim : int
         Hidden size of the GRU. Default: 4.
@@ -56,7 +55,7 @@ class UNetPlusPlusRNN(nn.Module):
     ValueError
         If the input does not have 4 channels.
     ValueError
-        If the input width does not match ``polymorphisms``.
+        If the input width does not match `polymorphisms`.
     """
 
     def __init__(
@@ -101,14 +100,14 @@ class UNetPlusPlusRNN(nn.Module):
         Parameters
         ----------
         x : torch.Tensor
-            Input tensor of shape ``(B, 4, H, W)``.
-            - ``x[:, 0:2]``: convolutional channels for UNet++.
-            - ``x[:, 2:4]``: neighbor-gap channels (gap_to_prev, gap_to_next).
+            Input tensor of shape `(B, 4, H, W)`.
+            - `x[:, 0:2]`: convolutional channels for UNet++.
+            - `x[:, 2:4]`: neighbor-gap channels (gap_to_prev, gap_to_next).
 
         Returns
         -------
         torch.Tensor
-            Output tensor of shape ``(B, H, W)``.
+            Output tensor of shape `(B, H, W)`.
         """
         if x.shape[1] != 4:
             raise ValueError(f"Expected 4 input channels, got {x.shape[1]}.")

--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import h5py, os
 from typing import Optional
@@ -77,54 +76,54 @@ class UNetModel(MlModel):
         Train a UNet model on an HDF5 dataset and save the best weights.
 
         This training routine assumes the unified HDF5 schema produced by
-        ``write_h5(..., ds_type="train")``. The HDF5 file stores all genotype matrices
+        `write_h5(..., ds_type="train")`. The HDF5 file stores all genotype matrices
         as dense datasets under fixed paths. Each genotype matrix is one training sample.
 
         HDF5 schema (training)
         ----------------------
         Inputs (always required)
-        - ``/data/Ref_genotype`` : uint32, shape (n, N, L)
-        - ``/data/Tgt_genotype`` : uint32, shape (n, N, L)
-        - ``/data/Gap_to_prev``  : int64,  shape (n, N, L)
-        - ``/data/Gap_to_next``  : int64,  shape (n, N, L)
+        - `/data/Ref_genotype` : uint32, shape (n, N, L)
+        - `/data/Tgt_genotype` : uint32, shape (n, N, L)
+        - `/data/Gap_to_prev`  : int64,  shape (n, N, L)
+        - `/data/Gap_to_next`  : int64,  shape (n, N, L)
 
         Targets (required for training)
-        - ``/targets/Label``     : uint8,  shape (n, N, L)
+        - `/targets/Label`     : uint8,  shape (n, N, L)
 
         Metadata
-        - ``/meta`` attributes include ``n``, ``N`` and ``L``.
+        - `/meta` attributes include `n`, `N` and `L`.
 
         Batch semantics
         --------------
         The DataLoader draws individual replicates and stacks them into batches. With
-        ``batch_size=B`` and ``add_rnn``:
+        `batch_size=B` and `add_rnn`:
 
-        - If ``add_rnn=False``: model inputs are constructed as 2 channels
-          ``[Ref_genotype, Tgt_genotype]`` and the batch tensor has shape ``(B, 2, N, L)``.
-        - If ``add_rnn=True``: model inputs are constructed as 4 channels
-          ``[Ref_genotype, Tgt_genotype, Gap_to_prev, Gap_to_next]`` and the batch tensor
-          has shape ``(B, 4, N, L)``.
+        - If `add_rnn=False`: model inputs are constructed as 2 channels
+          `[Ref_genotype, Tgt_genotype]` and the batch tensor has shape `(B, 2, N, L)`.
+        - If `add_rnn=True`: model inputs are constructed as 4 channels
+          `[Ref_genotype, Tgt_genotype, Gap_to_prev, Gap_to_next]` and the batch tensor
+          has shape `(B, 4, N, L)`.
 
-        Labels are loaded from ``/targets/Label`` and collated as ``(B, 1, N, L)``.
-        During training, the label channel dimension is removed via ``y = y.squeeze(1)``
-        to match a binary-logit output of shape ``(B, N, L)``.
+        Labels are loaded from `/targets/Label` and collated as `(B, 1, N, L)`.
+        During training, the label channel dimension is removed via `y = y.squeeze(1)`
+        to match a binary-logit output of shape `(B, N, L)`.
 
         Train/validation split
         ----------------------
         Replicates are split deterministically into training and validation subsets by
-        shuffling replicate indices with ``seed`` and taking ``val_prop`` as validation.
-        The selected indices are returned by ``build_dataloaders_from_h5``.
+        shuffling replicate indices with `seed` and taking `val_prop` as validation.
+        The selected indices are returned by `build_dataloaders_from_h5`.
 
         Class imbalance
         ---------------
         A negative-to-positive ratio is computed over the training replicates only from
-        ``/targets/Label`` and used as ``pos_weight`` in ``BCEWithLogitsLoss``.
+        `/targets/Label` and used as `pos_weight` in `BCEWithLogitsLoss`.
 
         Outputs
         -------
-        1. ``output``: model weights with the lowest validation loss
-        2. ``training.log``: periodic training loss and accuracy
-        3. ``validation.log``: validation loss and accuracy per epoch
+        1. `output`: model weights with the lowest validation loss
+        2. `training.log`: periodic training loss and accuracy
+        3. `validation.log`: validation loss and accuracy per epoch
 
         Parameters
         ----------
@@ -154,30 +153,30 @@ class UNetModel(MlModel):
         seed : int, optional
             Seed used for deterministic train/validation split and for label smoothing.
             Default: None.
-        device : Optional[str].
-            Force device string like ``"cuda:0"`` or ``"cpu"``. Default: None.
+        device : Optional[str], optional
+            Force device string like `"cuda:0"` or `"cpu"`. Default: None.
         num_workers : int, optional
             Number of DataLoader worker processes used for training/validation
             loaders. Default: 0.
         train_drop_last : Optional[bool], optional
             Whether to drop the final incomplete batch in the training DataLoader.
-            If None, use ``build_dataloaders_from_h5`` default. Default: None.
+            If None, use `build_dataloaders_from_h5` default. Default: None.
         val_drop_last : Optional[bool], optional
             Whether to drop the final incomplete batch in the validation DataLoader.
-            If None, use ``build_dataloaders_from_h5`` default. Default: None.
+            If None, use `build_dataloaders_from_h5` default. Default: None.
         persistent_workers : Optional[bool], optional
             Keep DataLoader worker processes alive across epochs to reduce worker
-            startup overhead. Effective only when ``num_workers > 0``. When None,
-            defer to ``build_dataloaders_from_h5`` defaults. Default: None.
+            startup overhead. Effective only when `num_workers > 0`. When None,
+            defer to `build_dataloaders_from_h5` defaults. Default: None.
         prefetch_factor : Optional[int], optional
             Number of batches prefetched by each DataLoader worker. Must be a
-            positive integer when set. Effective only when ``num_workers > 0``.
-            When None, defer to ``build_dataloaders_from_h5`` defaults.
+            positive integer when set. Effective only when `num_workers > 0`.
+            When None, defer to `build_dataloaders_from_h5` defaults.
             Default: None.
         use_amp : bool, optional
             Enable CUDA AMP training/inference execution path. When True and CUDA is
             used, forward/loss runs under autocast and backpropagation uses
-            ``GradScaler``. Default: False.
+            `GradScaler`. Default: False.
 
         Raises
         ------
@@ -186,7 +185,7 @@ class UNetModel(MlModel):
         ValueError
             If training labels contain no positive class.
         ValueError
-            If ``num_workers`` is not a non-negative integer.
+            If `num_workers` is not a non-negative integer.
         KeyError
             If required datasets are missing from the HDF5 file.
         """
@@ -377,23 +376,23 @@ class UNetModel(MlModel):
         """
         Run inference on an HDF5 file and write an aggregated prediction table.
 
-        This function reads model inputs from the unified, genotype-matrix-indexed layout in ``data`` and
+        This function reads model inputs from the unified, genotype-matrix-indexed layout in `data` and
         runs batched PyTorch inference. It aggregates window-level logits across overlapping windows (and across
         upsampled/repeated rows that map back to the same original target sample) using
-        ``/index/tgt_ids`` and ``/coords/Position``. For each target sample and each global position,
+        `/index/tgt_ids` and `/coords/Position`. For each target sample and each global position,
         logits are accumulated (sum and count), converted to mean logits, and then transformed into
         probabilities (sigmoid for binary, softmax for multiclass). Results are written as a TSV table
-        to ``output``.
+        to `output`.
 
-        Inputs are read from ``/data/Ref_genotype`` and ``/data/Tgt_genotype``. If ``add_rnn`` is
-        True, the additional channels are read from ``/data/Gap_to_prev`` and ``/data/Gap_to_next``.
-        The window length ``L`` is taken from ``/meta`` (and must match the last dimension of the
+        Inputs are read from `/data/Ref_genotype` and `/data/Tgt_genotype`. If `add_rnn` is
+        True, the additional channels are read from `/data/Gap_to_prev` and `/data/Gap_to_next`.
+        The window length `L` is taken from `/meta` (and must match the last dimension of the
         input datasets). The set of global positions is computed as the unique union of
-        ``/coords/Position`` values over the written windows.
+        `/coords/Position` values over the written windows.
 
         The output table is long-form and contains one row per (target sample, position). For binary
-        classification the columns are: ``sample``, ``position``, ``prob``, ``count``. For multiclass
-        classification the columns are: ``sample``, ``position``, ``count``, and ``prob_0..prob_{C-1}``,
+        classification the columns are: `sample`, `position`, `prob`, `count`. For multiclass
+        classification the columns are: `sample`, `position`, `count`, and `prob_0..prob_{C-1}`,
         where probabilities sum to 1 across classes for each (sample, position).
 
         Parameters
@@ -401,33 +400,33 @@ class UNetModel(MlModel):
         data : str
             Path to the input HDF5 file in the unified schema.
         model : str
-            Path to a ``.safetensors`` checkpoint (e.g. ``best.safetensors``).
+            Path to a `.safetensors` checkpoint (e.g. `best.safetensors`).
         output : str
             Path to the output file.
         add_rnn : bool, optional
-            If False, use only ``Ref_genotype`` and ``Tgt_genotype`` (2 channels) and
-            instantiate ``UNetPlusPlus`` with ``input_channels=2``.
-            If True, require ``Gap_to_prev`` and ``Gap_to_next`` (4 channels total) and use
-            ``UNetPlusPlusRNN``. Default: False.
+            If False, use only `Ref_genotype` and `Tgt_genotype` (2 channels) and
+            instantiate `UNetPlusPlus` with `input_channels=2`.
+            If True, require `Gap_to_prev` and `Gap_to_next` (4 channels total) and use
+            `UNetPlusPlusRNN`. Default: False.
         batch_size : int, optional
             Number of genotype matrices/windows processed per forward pass. Default: 8.
         site_weighting : bool, optional
             Whether to apply within-window site weighting when aggregating overlapping windows into
-            global per-site predictions. If True, each site at relative offset ``t`` within a window
-            contributes with weight ``g[t]`` (a 1D Gaussian window; peak-normalized to 1), so that
+            global per-site predictions. If True, each site at relative offset `t` within a window
+            contributes with weight `g[t]` (a 1D Gaussian window; peak-normalized to 1), so that
             central sites receive higher weight than edge sites. If False, all sites are weighted
-            equally (equivalent to ``g[t]=1`` for all ``t``). Default: False.
-        device : Optional[str].
-            Force device string like ``"cuda:0"`` or ``"cpu"``. Default: None.
+            equally (equivalent to `g[t]=1` for all `t`). Default: False.
+        device : Optional[str], optional
+            Force device string like `"cuda:0"` or `"cpu"`. Default: None.
 
         Raises
         ------
         KeyError
-            If required unified-schema datasets are missing (e.g. ``/data/Ref_genotype``),
-            or if ``add_rnn`` is True but gap datasets are missing.
+            If required unified-schema datasets are missing (e.g. `/data/Ref_genotype`),
+            or if `add_rnn` is True but gap datasets are missing.
         ValueError
             If model output has an unexpected shape, or if configuration constraints are violated
-            (e.g. ``add_rnn=True`` with ``n_classes!=1``).
+            (e.g. `add_rnn=True` with `n_classes!=1`).
         """
         n_classes = 1
 

--- a/gaishi/multiprocessing/__init__.py
+++ b/gaishi/multiprocessing/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,5 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .mp_manager import mp_manager  # noqa: F401

--- a/gaishi/multiprocessing/mp_manager.py
+++ b/gaishi/multiprocessing/mp_manager.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import multiprocessing, queue, time
 import numpy as np

--- a/gaishi/parsers/__init__.py
+++ b/gaishi/parsers/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gaishi/parsers/argument_validation.py
+++ b/gaishi/parsers/argument_validation.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import argparse, os
 

--- a/gaishi/parsers/infer_parser.py
+++ b/gaishi/parsers/infer_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import argparse
 from gaishi.parsers.argument_validation import existed_file

--- a/gaishi/parsers/train_parser.py
+++ b/gaishi/parsers/train_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import argparse
 from gaishi.parsers.argument_validation import existed_file

--- a/gaishi/preprocess.py
+++ b/gaishi/preprocess.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, multiprocessing, yaml
 import pandas as pd

--- a/gaishi/preprocessors/__init__.py
+++ b/gaishi/preprocessors/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_preprocessor import GenericPreprocessor  # noqa: F401
 from .feature_vector_preprocessor import FeatureVectorPreprocessor  # noqa: F401

--- a/gaishi/preprocessors/feature_vector_preprocessor.py
+++ b/gaishi/preprocessors/feature_vector_preprocessor.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import yaml
 import numpy as np

--- a/gaishi/preprocessors/generic_preprocessor.py
+++ b/gaishi/preprocessors/generic_preprocessor.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 

--- a/gaishi/preprocessors/genotype_matrix_preprocessor.py
+++ b/gaishi/preprocessors/genotype_matrix_preprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from typing import Any

--- a/gaishi/registries/__init__.py
+++ b/gaishi/registries/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_registry import GenericRegistry  # noqa: F401
 from .model_registry import ModelRegistry  # noqa: F401

--- a/gaishi/registries/generic_registry.py
+++ b/gaishi/registries/generic_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable

--- a/gaishi/registries/model_registry.py
+++ b/gaishi/registries/model_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from gaishi.registries.generic_registry import GenericRegistry
 

--- a/gaishi/registries/stat_registry.py
+++ b/gaishi/registries/stat_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from gaishi.registries.generic_registry import GenericRegistry
 

--- a/gaishi/simulate.py
+++ b/gaishi/simulate.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, random, shutil
 import pandas as pd

--- a/gaishi/simulators/__init__.py
+++ b/gaishi/simulators/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_simulator import GenericSimulator  # noqa: F401
 from .msprime_simulator import MsprimeSimulator  # noqa: F401

--- a/gaishi/simulators/feature_vector_simulator.py
+++ b/gaishi/simulators/feature_vector_simulator.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os
 from typing import Any

--- a/gaishi/simulators/generic_simulator.py
+++ b/gaishi/simulators/generic_simulator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 

--- a/gaishi/simulators/genotype_matrix_simulator.py
+++ b/gaishi/simulators/genotype_matrix_simulator.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import h5py
 import multiprocessing

--- a/gaishi/simulators/msprime_simulator.py
+++ b/gaishi/simulators/msprime_simulator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import demes, msprime, os, tskit
 import pyranges as pr
@@ -116,14 +116,14 @@ class MsprimeSimulator(GenericSimulator):
 
         Parameters
         ----------
-        rep : int or None
+        rep : int or None, optional
             Used to specify the replicate number for the simulation. This attribute is not set
             in the constructor but should be assigned before running simulations that require
-            tracking or distinguishing between multiple replicates.
-        seed : int or None
+            tracking or distinguishing between multiple replicates. Default: None.
+        seed : int or None, optional
             Seed for the random number generator to ensure reproducibility of the simulations.
             Similar to `rep`, this is not directly set in the constructor but should be specified
-            to ensure that simulations can be reproduced exactly.
+            to ensure that simulations can be reproduced exactly. Default: None.
 
         Returns
         -------

--- a/gaishi/stats/__init__.py
+++ b/gaishi/stats/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .generic_statistic import GenericStatistic  # noqa: F401
 from .spectrum import Spectrum  # noqa: F401

--- a/gaishi/stats/distance.py
+++ b/gaishi/stats/distance.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import scipy
 import numpy as np

--- a/gaishi/stats/generic_statistic.py
+++ b/gaishi/stats/generic_statistic.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from abc import ABC, abstractmethod
 from typing import Dict, Any

--- a/gaishi/stats/metrics.py
+++ b/gaishi/stats/metrics.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gaishi/stats/private_mutation.py
+++ b/gaishi/stats/private_mutation.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from typing import Dict, Any

--- a/gaishi/stats/spectrum.py
+++ b/gaishi/stats/spectrum.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from typing import Any, Dict

--- a/gaishi/stats/sstar.py
+++ b/gaishi/stats/sstar.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 from typing import Dict, Any, List
@@ -102,12 +101,12 @@ class Sstar(GenericStatistic):
             (n_sites, n_samples) target genotype matrix.
         pos : np.ndarray
             Positions of length n_sites (same row order as tgt_gt).
-        match_bonus : int
-            Bonus for pairs with gd==0 and distance ≥ 10.
-        max_mismatch : int
-            Maximum gd allowed for a mismatch pair.
-        mismatch_penalty : int
-            Penalty for 0 < gd ≤ max_mismatch; pairs with gd > max_mismatch are invalid.
+        match_bonus : int, optional
+            Bonus for pairs with gd==0 and distance ≥ 10. Default: 5000.
+        max_mismatch : int, optional
+            Maximum gd allowed for a mismatch pair. Default: 5.
+        mismatch_penalty : int, optional
+            Penalty for 0 < gd ≤ max_mismatch; pairs with gd > max_mismatch are invalid. Default: -10000.
 
         Returns
         -------

--- a/gaishi/train.py
+++ b/gaishi/train.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os
 import yaml

--- a/gaishi/utils/__init__.py
+++ b/gaishi/utils/__init__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from .utils import *  # noqa: F401
 from .unique_key_loader import UniqueKeyLoader  # noqa: F401

--- a/gaishi/utils/io.py
+++ b/gaishi/utils/io.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import h5py
 import multiprocessing
@@ -64,17 +63,17 @@ def write_h5(
 
     This function appends one or more entries into a pre-initialized HDF5 file opened in
     append/update mode by the caller (typically mode "a" inside the function). It writes
-    only model inputs and, for ``ds_type="train"``, the supervision targets. Prediction
+    only model inputs and, for `ds_type="train"`, the supervision targets. Prediction
     outputs such as logits are not written here.
 
     Data are stored in a unified, slice-friendly layout where the first dimension indexes
     replicates or windows. Sample order may differ between entries due to per-entry sorting.
-    Therefore, per-entry row identity is stored as integer ids (``/index/ref_ids`` and
-    ``/index/tgt_ids``) that point to global sample tables stored once in ``/meta``.
+    Therefore, per-entry row identity is stored as integer ids (`/index/ref_ids` and
+    `/index/tgt_ids`) that point to global sample tables stored once in `/meta`.
 
     This function assumes the file has already been initialized (datasets created and
-    ``/meta`` attributes present, including ``n`` and ``n_written``). New entries are written
-    starting at ``row = /meta.attrs["n_written"]`` and ``n_written`` is incremented accordingly.
+    `/meta` attributes present, including `n` and `n_written`). New entries are written
+    starting at `row = /meta.attrs["n_written"]` and `n_written` is incremented accordingly.
 
     Parameters
     ----------
@@ -83,21 +82,21 @@ def write_h5(
     entries : Mapping[str, Any] or Sequence[Mapping[str, Any]]
         One entry or a list of entries. Each entry corresponds to one replicate/window.
 
-        Required keys for both ``ds_type="train"`` and ``ds_type="infer"``:
-        - ``Ref_genotype`` : array_like, shape (N, L)
-        - ``Tgt_genotype`` : array_like, shape (N, L)
-        - ``Gap_to_prev``  : array_like, shape (N, L)
-        - ``Gap_to_next``  : array_like, shape (N, L)
-        - ``Ref_sample``   : sequence of length N, sample names in row order
-        - ``Tgt_sample``   : sequence of length N, sample names in row order
+        Required keys for both `ds_type="train"` and `ds_type="infer"`:
+        - `Ref_genotype` : array_like, shape (N, L)
+        - `Tgt_genotype` : array_like, shape (N, L)
+        - `Gap_to_prev`  : array_like, shape (N, L)
+        - `Gap_to_next`  : array_like, shape (N, L)
+        - `Ref_sample`   : sequence of length N, sample names in row order
+        - `Tgt_sample`   : sequence of length N, sample names in row order
 
-        Additional required keys for ``ds_type="train"``:
-        - ``Label``     : array_like, shape (N, L)
-        - ``Seed``      : scalar
-        - ``Replicate`` : scalar
+        Additional required keys for `ds_type="train"`:
+        - `Label`     : array_like, shape (N, L)
+        - `Seed`      : scalar
+        - `Replicate` : scalar
 
-        Additional required keys for ``ds_type="infer"``:
-        - ``Position``  : array_like, shape (L,)
+        Additional required keys for `ds_type="infer"`:
+        - `Position`  : array_like, shape (L,)
     ds_type : {"train", "infer"}
         Dataset type. Controls whether training targets or inference coordinates are written.
     lock : multiprocessing.Lock
@@ -105,28 +104,28 @@ def write_h5(
 
     Notes
     -----
-    Expected HDF5 schema (created elsewhere, e.g. by ``initialize_h5``).
+    Expected HDF5 schema (created elsewhere, e.g. by `initialize_h5`).
 
     Common datasets
-    - ``/data/Ref_genotype``  : uint32, shape (n, N, L)
-    - ``/data/Tgt_genotype``  : uint32, shape (n, N, L)
-    - ``/data/Gap_to_prev``   : int64,  shape (n, N, L)
-    - ``/data/Gap_to_next``   : int64,  shape (n, N, L)
-    - ``/index/ref_ids``      : uint32, shape (n, N)
-    - ``/index/tgt_ids``      : uint32, shape (n, N)
-    - ``/meta/ref_sample_table`` : utf-8 strings, shape (K_ref,)
-    - ``/meta/tgt_sample_table`` : utf-8 strings, shape (K_tgt,)
-    - ``/meta`` attributes: ``n``, ``N``, ``L``, ``Chromosome``, ``n_written``
+    - `/data/Ref_genotype`  : uint32, shape (n, N, L)
+    - `/data/Tgt_genotype`  : uint32, shape (n, N, L)
+    - `/data/Gap_to_prev`   : int64,  shape (n, N, L)
+    - `/data/Gap_to_next`   : int64,  shape (n, N, L)
+    - `/index/ref_ids`      : uint32, shape (n, N)
+    - `/index/tgt_ids`      : uint32, shape (n, N)
+    - `/meta/ref_sample_table` : utf-8 strings, shape (K_ref,)
+    - `/meta/tgt_sample_table` : utf-8 strings, shape (K_tgt,)
+    - `/meta` attributes: `n`, `N`, `L`, `Chromosome`, `n_written`
 
-    Training-only datasets (``ds_type="train"``)
-    - ``/targets/Label``      : uint8,  shape (n, N, L)
-    - ``/index/Seed``         : int64,  shape (n,)
-    - ``/index/Replicate``    : int64,  shape (n,)
+    Training-only datasets (`ds_type="train"`)
+    - `/targets/Label`      : uint8,  shape (n, N, L)
+    - `/index/Seed`         : int64,  shape (n,)
+    - `/index/Replicate`    : int64,  shape (n,)
 
-    Inference-only datasets (``ds_type="infer"``)
-    - ``/coords/Position``    : int64,  shape (n, L)
+    Inference-only datasets (`ds_type="infer"`)
+    - `/coords/Position`    : int64,  shape (n, L)
 
-    The integer row id arrays map each row in ``Ref_genotype`` and ``Tgt_genotype`` back to
+    The integer row id arrays map each row in `Ref_genotype` and `Tgt_genotype` back to
     the global sample tables. This preserves per-entry sorting while still allowing efficient
     slicing across entries.
     """
@@ -293,8 +292,8 @@ def initialize_h5(
         Reference sample name table written once to /meta/ref_sample_table.
     tgt_table : list[str]
         Target sample name table written once to /meta/tgt_sample_table.
-    compression : str, default "lzf"
-        HDF5 dataset compression filter.
+    compression : str, optional
+        HDF5 dataset compression filter. Default: "lzf".
 
     Raises
     ------

--- a/gaishi/utils/unique_key_loader.py
+++ b/gaishi/utils/unique_key_loader.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 from typing import Any, Dict
 
@@ -43,8 +42,8 @@ def no_duplicate_keys(
         The YAML loader instance (based on SafeLoader).
     node : yaml.nodes.MappingNode
         The mapping node being constructed.
-    deep : bool
-        Whether to construct nested objects deeply (passed through to the loader).
+    deep : bool, optional
+        Whether to construct nested objects deeply (passed through to the loader). Default: False.
 
     Returns
     -------

--- a/gaishi/utils/utils.py
+++ b/gaishi/utils/utils.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import allel
 import math

--- a/tests/configs/test_feature_config.py
+++ b/tests/configs/test_feature_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from pydantic import ValidationError

--- a/tests/configs/test_global_config.py
+++ b/tests/configs/test_global_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from pathlib import Path

--- a/tests/configs/test_model_config.py
+++ b/tests/configs/test_model_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from typing import Any

--- a/tests/configs/test_preprocess_config.py
+++ b/tests/configs/test_preprocess_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 # tests/test_preprocess_config.py
 
@@ -70,9 +69,7 @@ def test_preprocess_config_valid():
 
 @pytest.mark.parametrize("field", ["win_len", "win_step", "nprocess", "ploidy"])
 @pytest.mark.parametrize("bad_value", [0, -1])
-def test_preprocess_config_positive_int_fields_must_be_gt_zero(
-    field: str, bad_value: int
-):
+def test_preprocess_config_positive_int_fields_must_be_gt_zero(field, bad_value):
     kwargs = _valid_kwargs()
     kwargs[field] = bad_value
 

--- a/tests/configs/test_simulation_config.py
+++ b/tests/configs/test_simulation_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from pathlib import Path
@@ -132,9 +131,7 @@ def test_genotype_matrix_simulation_config_valid():
     ],
 )
 @pytest.mark.parametrize("bad_value", [0, -1])
-def test_simulation_config_positive_int_fields_must_be_gt_zero(
-    field: str, bad_value: int
-):
+def test_simulation_config_positive_int_fields_must_be_gt_zero(field, bad_value):
     kwargs = _valid_feature_vector_kwargs()
     kwargs[field] = bad_value
     with pytest.raises(ValidationError):
@@ -147,7 +144,7 @@ def test_simulation_config_positive_int_fields_must_be_gt_zero(
 
 
 @pytest.mark.parametrize("bad_value", [0.0, -1e-8])
-def test_simulation_config_mut_rate_must_be_strictly_positive(bad_value: float):
+def test_simulation_config_mut_rate_must_be_strictly_positive(bad_value):
     kwargs = _valid_feature_vector_kwargs()
     kwargs["mut_rate"] = bad_value
     with pytest.raises(ValidationError):
@@ -160,7 +157,7 @@ def test_simulation_config_mut_rate_must_be_strictly_positive(bad_value: float):
 
 
 @pytest.mark.parametrize("bad_value", [-1e-8])
-def test_simulation_config_rec_rate_must_be_ge_zero(bad_value: float):
+def test_simulation_config_rec_rate_must_be_ge_zero(bad_value):
     kwargs = _valid_feature_vector_kwargs()
     kwargs["rec_rate"] = bad_value
     with pytest.raises(ValidationError):
@@ -174,9 +171,7 @@ def test_simulation_config_rec_rate_must_be_ge_zero(bad_value: float):
 
 @pytest.mark.parametrize("field", ["intro_prop", "non_intro_prop"])
 @pytest.mark.parametrize("value", [0.0, 0.5, 1.0])
-def test_feature_vector_simulation_config_props_in_closed_interval(
-    field: str, value: float
-):
+def test_feature_vector_simulation_config_props_in_closed_interval(field, value):
     kwargs = _valid_feature_vector_kwargs()
     kwargs[field] = value
     cfg = FeatureVectorSimulationConfig(**kwargs)
@@ -185,7 +180,7 @@ def test_feature_vector_simulation_config_props_in_closed_interval(
 
 @pytest.mark.parametrize("field", ["intro_prop", "non_intro_prop"])
 @pytest.mark.parametrize("value", [-0.1, 1.1])
-def test_feature_vector_simulation_config_props_out_of_range(field: str, value: float):
+def test_feature_vector_simulation_config_props_out_of_range(field, value):
     kwargs = _valid_feature_vector_kwargs()
     kwargs[field] = value
     with pytest.raises(ValidationError):
@@ -195,7 +190,7 @@ def test_feature_vector_simulation_config_props_out_of_range(field: str, value: 
 @pytest.mark.parametrize("field", ["num_polymorphisms"])
 @pytest.mark.parametrize("bad_value", [0, -1])
 def test_genotype_matrix_simulation_config_specific_fields_must_be_gt_zero(
-    field: str, bad_value: int
+    field, bad_value
 ):
     kwargs = _valid_genotype_matrix_kwargs()
     kwargs[field] = bad_value

--- a/tests/generators/test_polymorphism_data_generator.py
+++ b/tests/generators/test_polymorphism_data_generator.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os
 import pytest

--- a/tests/generators/test_random_number_generator.py
+++ b/tests/generators/test_random_number_generator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from gaishi.generators import RandomNumberGenerator

--- a/tests/generators/test_window_data_generator.py
+++ b/tests/generators/test_window_data_generator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest
 import numpy as np

--- a/tests/labelers/test_binary_allele_labeler.py
+++ b/tests/labelers/test_binary_allele_labeler.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import allel
 import pytest

--- a/tests/labelers/test_binary_window_labeler.py
+++ b/tests/labelers/test_binary_window_labeler.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, shutil
 import numpy as np

--- a/tests/models/test_etc_model.py
+++ b/tests/models/test_etc_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import joblib, os, pytest, shutil
 import pandas as pd

--- a/tests/models/test_lr_model.py
+++ b/tests/models/test_lr_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import joblib, os, pytest, shutil
 import pandas as pd

--- a/tests/models/unet/layers/test_residual_concat_block.py
+++ b/tests/models/unet/layers/test_residual_concat_block.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import torch

--- a/tests/models/unet/layers/test_unet_plus_plus.py
+++ b/tests/models/unet/layers/test_unet_plus_plus.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import torch

--- a/tests/models/unet/layers/test_unet_plus_plus_rnn.py
+++ b/tests/models/unet/layers/test_unet_plus_plus_rnn.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import torch

--- a/tests/models/unet/test_dataloader_h5.py
+++ b/tests/models/unet/test_dataloader_h5.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import h5py
 import numpy as np
 import pytest
@@ -31,12 +30,12 @@ from gaishi.models.unet.dataloader_h5 import (  # noqa: F401
 
 
 def _write_h5(
-    path: str,
+    path,
     *,
-    R: int = 8,
-    N: int = 3,
-    L: int = 5,
-    with_labels: bool = True,
+    R=8,
+    N=3,
+    L=5,
+    with_labels=True,
 ):
     rng = np.random.default_rng(42)
 

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -17,7 +17,6 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-
 import h5py, math, pickle
 import numpy as np
 import os, pytest, torch
@@ -31,7 +30,7 @@ class DummyUNetPlusPlus(nn.Module):
 
     last_init = None
 
-    def __init__(self, num_classes: int, input_channels: int = 3):
+    def __init__(self, num_classes, input_channels=3):
         super().__init__()
         self.num_classes = int(num_classes)
         DummyUNetPlusPlus.last_init = {
@@ -40,7 +39,7 @@ class DummyUNetPlusPlus(nn.Module):
         }
         self.head = nn.Conv2d(int(input_channels), int(num_classes), kernel_size=1)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         logits = self.head(x)
         return logits
 
@@ -52,11 +51,11 @@ class DummyUNetPlusPlusRNN(nn.Module):
 
     def __init__(
         self,
-        num_classes: int = 1,
-        polymorphisms: int = 128,
-        hidden_dim: int = 4,
-        gru_layers: int = 1,
-        bidirectional: bool = True,
+        num_classes=1,
+        polymorphisms=128,
+        hidden_dim=4,
+        gru_layers=1,
+        bidirectional=True,
     ):
         super().__init__()
         self.polymorphisms = int(polymorphisms)
@@ -68,7 +67,7 @@ class DummyUNetPlusPlusRNN(nn.Module):
         }
         self.scale = nn.Parameter(torch.tensor(1.0))
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         if x.shape[1] != 4:
             raise ValueError(f"Expected 4 input channels, got {x.shape[1]}.")
         if x.shape[-1] != self.polymorphisms:
@@ -79,12 +78,12 @@ class DummyUNetPlusPlusRNN(nn.Module):
 def _make_training_h5(
     tmp_path,
     *,
-    n_reps: int,
-    N: int,
-    L: int,
-    with_gaps: bool = True,
-    force_no_positive: bool = False,
-) -> str:
+    n_reps,
+    N,
+    L,
+    with_gaps=True,
+    force_no_positive=False,
+):
     """
     Create a unified-schema training HDF5 file.
 
@@ -153,7 +152,7 @@ def _make_training_h5(
     return str(h5_path)
 
 
-def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch) -> None:
+def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -191,7 +190,7 @@ def test_train_branch_unetplusplus_two_channel(tmp_path, monkeypatch) -> None:
     assert "device = cpu" in training_log.read_text()
 
 
-def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch) -> None:
+def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -220,9 +219,7 @@ def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch) ->
     assert DummyUNetPlusPlusRNN.last_init["polymorphisms"] == 11
 
 
-def test_train_raises_when_add_rnn_true_but_missing_gap_datasets(
-    tmp_path, monkeypatch
-) -> None:
+def test_train_raises_when_add_rnn_true_but_missing_gap_datasets(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -245,7 +242,7 @@ def test_train_raises_when_add_rnn_true_but_missing_gap_datasets(
         )
 
 
-def test_train_raises_when_no_positive_class(tmp_path, monkeypatch) -> None:
+def test_train_raises_when_no_positive_class(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -272,12 +269,12 @@ def test_train_raises_when_no_positive_class(tmp_path, monkeypatch) -> None:
 class DummyUNetPlusPlus2(nn.Module):
     """Return logits derived from input (deterministic)."""
 
-    def __init__(self, num_classes: int = 1, input_channels: int = 2):
+    def __init__(self, num_classes=1, input_channels=2):
         super().__init__()
         self.num_classes = int(num_classes)
         self.input_channels = int(input_channels)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         # x: (B, Cin, N, L), we use tgt channel = 1
         tgt = x[:, 1:2, :, :]  # (B, 1, N, L)
         if self.num_classes == 1:
@@ -295,11 +292,11 @@ class DummyUNetPlusPlus2(nn.Module):
 class DummyUNetPlusPlusRNN2(nn.Module):
     """4-channel dummy; return logits=tgt channel."""
 
-    def __init__(self, num_classes: int = 1, polymorphisms: int = 128, **kwargs):
+    def __init__(self, num_classes=1, polymorphisms=128, **kwargs):
         super().__init__()
         self.polymorphisms = int(polymorphisms)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         # expect 4 channels when add_rnn=True
         if x.shape[1] != 4:
             raise ValueError(f"Expected 4 input channels, got {x.shape[1]}.")
@@ -308,14 +305,14 @@ class DummyUNetPlusPlusRNN2(nn.Module):
         return x[:, 1:2, :, :]  # ref channel = 0, tgt channel = 1, (B, 1, N, L)
 
 
-def _save_weights(tmp_path, model, filename) -> str:
+def _save_weights(tmp_path, model, filename):
     weights_path = tmp_path / filename
     save_file(model.state_dict(), str(weights_path))
 
     return str(weights_path)
 
 
-def _make_inference_h5(tmp_path, *, with_gaps: bool, L: int = 5) -> str:
+def _make_inference_h5(tmp_path, *, with_gaps, L=5):
     """
     n=2 windows, H=2 unique tgt samples (A,B), N=3 rows per window (upsampling: [A,B,A]).
     positions overlap: window0 = 100..104, window1 = 102..106
@@ -406,12 +403,12 @@ def _make_inference_h5(tmp_path, *, with_gaps: bool, L: int = 5) -> str:
     return str(h5_path)
 
 
-def _sigmoid_scalar(x: float) -> float:
+def _sigmoid_scalar(x):
     x = max(-60.0, min(60.0, x))
     return 1.0 / (1.0 + math.exp(-x))
 
 
-def _gauss_weights(L: int, sigma: float) -> np.ndarray:
+def _gauss_weights(L, sigma):
     mu = L // 2
     x = np.arange(L, dtype=np.float64)
     g = np.exp(-((x - mu) ** 2) / (2.0 * sigma * sigma))
@@ -419,7 +416,7 @@ def _gauss_weights(L: int, sigma: float) -> np.ndarray:
     return g.astype(np.float64)
 
 
-def _read_prob_table(path: str) -> dict[tuple[str, int], list[float]]:
+def _read_prob_table(path):
     """
     Returns mapping (sample, position) -> [Non_Intro_Prob, Intro_Prob]
     """
@@ -448,7 +445,7 @@ def _read_prob_table(path: str) -> dict[tuple[str, int], list[float]]:
     return out
 
 
-def test_train_raises_when_num_workers_is_negative(tmp_path, monkeypatch) -> None:
+def test_train_raises_when_num_workers_is_negative(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -470,7 +467,7 @@ def test_train_raises_when_num_workers_is_negative(tmp_path, monkeypatch) -> Non
         )
 
 
-def test_train_passes_drop_last_flags_to_dataloader(tmp_path, monkeypatch) -> None:
+def test_train_passes_drop_last_flags_to_dataloader(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -506,9 +503,7 @@ def test_train_passes_drop_last_flags_to_dataloader(tmp_path, monkeypatch) -> No
     assert captured["val_drop_last"] is True
 
 
-def test_train_uses_dataloader_drop_last_defaults_when_none(
-    tmp_path, monkeypatch
-) -> None:
+def test_train_uses_dataloader_drop_last_defaults_when_none(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -542,7 +537,7 @@ def test_train_uses_dataloader_drop_last_defaults_when_none(
     assert "val_drop_last" not in captured
 
 
-def test_train_use_amp_true_on_cpu_safely_falls_back(tmp_path, monkeypatch) -> None:
+def test_train_use_amp_true_on_cpu_safely_falls_back(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
     training_data = _make_training_h5(tmp_path, n_reps=20, N=2, L=7, with_gaps=True)
@@ -565,9 +560,7 @@ def test_train_use_amp_true_on_cpu_safely_falls_back(tmp_path, monkeypatch) -> N
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_train_amp_cuda_branch_uses_scaler_with_monkeypatch(
-    tmp_path, monkeypatch
-) -> None:
+def test_train_amp_cuda_branch_uses_scaler_with_monkeypatch(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
     training_data = _make_training_h5(tmp_path, n_reps=20, N=2, L=7, with_gaps=True)
@@ -631,9 +624,7 @@ def test_train_amp_cuda_branch_uses_scaler_with_monkeypatch(
     assert calls["autocast"] > 0
 
 
-def test_infer_unetplusplus_two_channel_outputs_table_binary(
-    tmp_path, monkeypatch
-) -> None:
+def test_infer_unetplusplus_two_channel_outputs_table_binary(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus2)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN2)
 
@@ -661,9 +652,7 @@ def test_infer_unetplusplus_two_channel_outputs_table_binary(
     assert got_B_102 == pytest.approx(exp_B_102, rel=1e-6, abs=1e-6)
 
 
-def test_infer_unet_rnn_four_channel_outputs_table_binary(
-    tmp_path, monkeypatch
-) -> None:
+def test_infer_unet_rnn_four_channel_outputs_table_binary(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus2)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN2)
 
@@ -683,9 +672,7 @@ def test_infer_unet_rnn_four_channel_outputs_table_binary(
     assert tab[("B", 102)] == pytest.approx(_sigmoid_scalar(14.5), rel=1e-6, abs=1e-6)
 
 
-def test_infer_raises_when_add_rnn_true_but_missing_gap_datasets(
-    tmp_path, monkeypatch
-) -> None:
+def test_infer_raises_when_add_rnn_true_but_missing_gap_datasets(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus2)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN2)
 
@@ -702,7 +689,7 @@ def test_infer_raises_when_add_rnn_true_but_missing_gap_datasets(
         )
 
 
-def test_infer_site_weighting_changes_overlap_result(tmp_path, monkeypatch) -> None:
+def test_infer_site_weighting_changes_overlap_result(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus2)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN2)
 
@@ -744,7 +731,7 @@ def test_infer_site_weighting_changes_overlap_result(tmp_path, monkeypatch) -> N
     assert t1[("A", 102)] != pytest.approx(t0[("A", 102)], rel=1e-9, abs=1e-9)
 
 
-def test_binary_batch_accuracy_from_logits() -> None:
+def test_binary_batch_accuracy_from_logits():
     logits = torch.tensor([[-1.0, 2.0, 0.0, -0.1]])
     labels = torch.tensor([[0.0, 0.0, 1.0, 1.0]])
 
@@ -753,7 +740,7 @@ def test_binary_batch_accuracy_from_logits() -> None:
     assert accuracy == 0.5
 
 
-def test_binary_batch_accuracy_from_logits_zero_logit_is_positive() -> None:
+def test_binary_batch_accuracy_from_logits_zero_logit_is_positive():
     logits = torch.tensor([[0.0, -0.0, 1e-12, -1e-12]])
     labels = torch.tensor([[1.0, 1.0, 1.0, 0.0]])
 
@@ -762,7 +749,7 @@ def test_binary_batch_accuracy_from_logits_zero_logit_is_positive() -> None:
     assert accuracy == 1.0
 
 
-def test_train_passes_worker_perf_kwargs_to_dataloader(tmp_path, monkeypatch) -> None:
+def test_train_passes_worker_perf_kwargs_to_dataloader(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
@@ -799,9 +786,7 @@ def test_train_passes_worker_perf_kwargs_to_dataloader(tmp_path, monkeypatch) ->
     assert captured["prefetch_factor"] == 5
 
 
-def test_train_uses_dataloader_worker_perf_defaults_when_none(
-    tmp_path, monkeypatch
-) -> None:
+def test_train_uses_dataloader_worker_perf_defaults_when_none(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 

--- a/tests/multiprocessing/test_mp_manager.py
+++ b/tests/multiprocessing/test_mp_manager.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest, queue, time
 import numpy as np

--- a/tests/parsers/test_infer_parser.py
+++ b/tests/parsers/test_infer_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import argparse

--- a/tests/parsers/test_train_parser.py
+++ b/tests/parsers/test_train_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import argparse

--- a/tests/preprocessors/test_feature_vector_preprocessor.py
+++ b/tests/preprocessors/test_feature_vector_preprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, yaml
 import gaishi.stats

--- a/tests/preprocessors/test_genotype_matrix_preprocessor.py
+++ b/tests/preprocessors/test_genotype_matrix_preprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from gaishi.generators import PolymorphismDataGenerator

--- a/tests/registries/test_registries.py
+++ b/tests/registries/test_registries.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 from gaishi.registries import (

--- a/tests/simulators/test_feature_vector_simulator.py
+++ b/tests/simulators/test_feature_vector_simulator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, shutil
 import numpy as np

--- a/tests/simulators/test_genotype_matrix_simulator.py
+++ b/tests/simulators/test_genotype_matrix_simulator.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import h5py

--- a/tests/simulators/test_msprime_simulator.py
+++ b/tests/simulators/test_msprime_simulator.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, shutil
 from gaishi.multiprocessing import mp_manager

--- a/tests/stats/test_distance.py
+++ b/tests/stats/test_distance.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import scipy
 import numpy as np

--- a/tests/stats/test_private_mutation.py
+++ b/tests/stats/test_private_mutation.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import numpy as np

--- a/tests/stats/test_spectrum.py
+++ b/tests/stats/test_spectrum.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import numpy as np
 import pytest

--- a/tests/stats/test_sstar.py
+++ b/tests/stats/test_sstar.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import numpy as np

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest, os, signal, argparse
 from unittest.mock import patch

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, shutil
 import pandas as pd

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import h5py, os, pytest
 import numpy as np

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import os, pytest, shutil
 import numpy as np

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,5 +1,6 @@
+# Copyright 2026 Xin Huang
+#
 # GNU General Public License v3.0
-# Copyright 2024 Xin Huang
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import joblib, os, pytest, shutil
 import gaishi.models

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import copy, h5py
 import pytest
@@ -99,7 +98,7 @@ def test_write_tsv_appends_rows(tmp_path):
     assert lines == ["[1, 2]\t3", "[9, 8, 7]\t4"]
 
 
-def _read_str_1d(ds) -> list[str]:
+def _read_str_1d(ds):
     """Read a 1D h5py string dataset into Python strings."""
     out = []
     for x in ds[...]:
@@ -110,7 +109,7 @@ def _read_str_1d(ds) -> list[str]:
     return out
 
 
-def _assert_string_table(ds: h5py.Dataset, expected: list[str]) -> None:
+def _assert_string_table(ds, expected):
     # h5py vlen utf-8 strings often show up as dtype=object
     sdt = h5py.check_string_dtype(ds.dtype)
     assert sdt is not None

--- a/tests/utils/test_unique_key_loader.py
+++ b/tests/utils/test_unique_key_loader.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import yaml

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xin Huang
+# Copyright 2026 Xin Huang
 #
 # GNU General Public License v3.0
 #
@@ -16,7 +16,6 @@
 # along with this program. If not, please see
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
-
 
 import pytest
 import numpy as np


### PR DESCRIPTION
### Motivation
- Align configuration and code for the UNet model (`add_rnn` option) and prepare library metadata for 2026.
- Improve in-code documentation, type hints, and user-facing configuration examples to reduce ambiguity.
- Harmonize HDF5 I/O and dataloader docstrings to clarify schema, defaults, and runtime behavior.

### Description
- Replace `add_channels` with `add_rnn` in the example UNet YAML (`examples/configs/unet.training.yaml`) to match the `UNetModel.train` and `UNetModel.infer` parameter name. 
- Bump copyright headers across many modules from 2024/2025 to `2026`.
- Update numerous docstrings and inline documentation (models, UNet layers, dataloader, registries, simulators, preprocessors, stats, utils, IO) to clarify parameter types, defaults, HDF5 schema expectations, and formatting (use of inline code/backticks and optional/default wording). 
- Minor API/implementation clarifications in `dataloader_h5.py` and `io.py` documentation, including clearer default values for parameters and strengthened descriptions of `write_h5`/`initialize_h5` schema fields.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd119d73e0832c87a61120c4059c55)

## Summary by Sourcery

Align UNet configuration and documentation with the `add_rnn` parameter, refresh metadata for 2026, and clarify HDF5 I/O and dataloader behavior and defaults.

Enhancements:
- Standardize docstrings and inline documentation across UNet models, layers, dataloaders, simulators, stats, and utilities with clearer types, defaults, and HDF5 schema descriptions.
- Clarify default parameter values and configuration semantics for HDF5 dataloaders, label smoothing, device selection, and UNet RNN integration.
- Improve YAML UNet training example to use the `add_rnn` flag consistent with code parameters.

Build:
- Update copyright headers across the codebase to 2026 to keep project metadata current.