### PR TITLE
Add recent-500 batch metrics to UNet training logs

### DIFF
--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -18,6 +18,7 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import h5py, os
+from collections import deque
 from typing import Optional
 
 import numpy as np
@@ -32,6 +33,7 @@ from gaishi.models.unet.layers import UNetPlusPlus, UNetPlusPlusRNN
 from gaishi.registries.model_registry import MODEL_REGISTRY
 
 from gaishi.models.unet.dataloader_h5 import build_dataloaders_from_h5
+
 
 
 @MODEL_REGISTRY.register("unet++")
@@ -70,6 +72,7 @@ class UNetModel(MlModel):
         persistent_workers: Optional[bool] = None,
         prefetch_factor: Optional[int] = None,
         use_amp: bool = False,
+        recent_window: int = 500,
         **kwargs,
     ) -> None:
         """
@@ -177,6 +180,9 @@ class UNetModel(MlModel):
             Enable CUDA AMP training/inference execution path. When True and CUDA is
             used, forward/loss runs under autocast and backpropagation uses
             `GradScaler`. Default: False.
+        recent_window : int, optional
+            Sliding window size for recent batch loss/accuracy metrics logged every
+            1000 batches. Must be in the range [1, 1000]. Default: 500.
 
         Raises
         ------
@@ -217,6 +223,12 @@ class UNetModel(MlModel):
 
         if not isinstance(num_workers, int) or num_workers < 0:
             raise ValueError("`num_workers` must be a non-negative integer.")
+        if (
+            not isinstance(recent_window, int)
+            or recent_window <= 0
+            or recent_window > 1000
+        ):
+            raise ValueError("`recent_window` must be an integer in [1, 1000].")
 
         input_channels = 4 if add_rnn else 2
 
@@ -286,6 +298,8 @@ class UNetModel(MlModel):
             net.train()
             losses = []
             accuracies = []
+            recent_losses = deque(maxlen=int(recent_window))
+            recent_accuracies = deque(maxlen=int(recent_window))
 
             for batch_idx, (x, y) in enumerate(train_loader, start=1):
                 optimizer.zero_grad()
@@ -305,16 +319,24 @@ class UNetModel(MlModel):
                     loss.backward()
                     optimizer.step()
 
-                losses.append(loss.item())
+                batch_loss = loss.item()
+                batch_acc = _binary_batch_accuracy_from_logits(y_pred, y)
 
-                accuracies.append(_binary_batch_accuracy_from_logits(y_pred, y))
-
-                mean_loss = np.mean(losses)
-                mean_acc = np.mean(accuracies)
+                losses.append(batch_loss)
+                accuracies.append(batch_acc)
+                recent_losses.append(batch_loss)
+                recent_accuracies.append(batch_acc)
 
                 if batch_idx % 1000 == 0:
+                    mean_loss = np.mean(losses)
+                    mean_acc = np.mean(accuracies)
+                    recent_loss = np.mean(recent_losses)
+                    recent_acc = np.mean(recent_accuracies)
                     training_log_file.write(
-                        f"Epoch {epoch_idx}, batch {batch_idx}: loss = {mean_loss}, accuracy = {mean_acc}.\n"
+                        f"Epoch {epoch_idx}, batch {batch_idx}: "
+                        f"loss = {mean_loss}, accuracy = {mean_acc}, "
+                        f"recent{recent_window}_loss = {recent_loss}, "
+                        f"recent{recent_window}_accuracy = {recent_acc}.\n"
                     )
                     training_log_file.flush()
 

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -819,3 +819,98 @@ def test_train_uses_dataloader_worker_perf_defaults_when_none(tmp_path, monkeypa
 
     assert "persistent_workers" not in captured
     assert "prefetch_factor" not in captured
+
+
+def test_train_logs_recent500_metrics_every_1000_batches(tmp_path, monkeypatch):
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=20, N=2, L=7, with_gaps=True)
+    model_dir = tmp_path / "model_out_recent500"
+    model_path = model_dir / "best.safetensors"
+
+    xb = torch.zeros((1, 2, 2, 7), dtype=torch.float32)
+    yb = torch.zeros((1, 1, 2, 7), dtype=torch.float32)
+    train_loader = [(xb, yb)] * 1000
+    val_loader = [(xb, yb)]
+
+    def _fake_build_dataloaders_from_h5(**_kwargs):
+        return train_loader, val_loader, np.array([0]), np.array([1])
+
+    monkeypatch.setattr(unet_mod, "build_dataloaders_from_h5", _fake_build_dataloaders_from_h5)
+
+    unet_mod.UNetModel.train(
+        data=training_data,
+        output=str(model_path),
+        add_rnn=False,
+        batch_size=1,
+        n_epochs=1,
+        n_early=0,
+        min_delta=0.0,
+        val_prop=0.2,
+        seed=0,
+    )
+
+    training_log_text = (model_dir / "training.log").read_text()
+    assert "recent500_loss =" in training_log_text
+    assert "recent500_accuracy =" in training_log_text
+
+
+def test_train_logs_recent_window_metrics_with_custom_window(tmp_path, monkeypatch):
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=20, N=2, L=7, with_gaps=True)
+    model_dir = tmp_path / "model_out_recent_custom"
+    model_path = model_dir / "best.safetensors"
+
+    xb = torch.zeros((1, 2, 2, 7), dtype=torch.float32)
+    yb = torch.zeros((1, 1, 2, 7), dtype=torch.float32)
+    train_loader = [(xb, yb)] * 1000
+    val_loader = [(xb, yb)]
+
+    def _fake_build_dataloaders_from_h5(**_kwargs):
+        return train_loader, val_loader, np.array([0]), np.array([1])
+
+    monkeypatch.setattr(
+        unet_mod, "build_dataloaders_from_h5", _fake_build_dataloaders_from_h5
+    )
+
+    unet_mod.UNetModel.train(
+        data=training_data,
+        output=str(model_path),
+        add_rnn=False,
+        batch_size=1,
+        n_epochs=1,
+        n_early=0,
+        min_delta=0.0,
+        val_prop=0.2,
+        seed=0,
+        recent_window=123,
+    )
+
+    training_log_text = (model_dir / "training.log").read_text()
+    assert "recent123_loss =" in training_log_text
+    assert "recent123_accuracy =" in training_log_text
+
+
+def test_train_raises_for_recent_window_greater_than_1000(tmp_path, monkeypatch):
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
+
+    training_data = _make_training_h5(tmp_path, n_reps=10, N=2, L=7, with_gaps=True)
+    model_path = tmp_path / "model_out_recent_window_limit" / "best.safetensors"
+
+    with pytest.raises(ValueError, match=r"`recent_window` must be an integer in \[1, 1000\]\."):
+        unet_mod.UNetModel.train(
+            data=training_data,
+            output=str(model_path),
+            add_rnn=False,
+            batch_size=2,
+            n_epochs=1,
+            n_early=0,
+            min_delta=0.0,
+            val_prop=0.2,
+            seed=0,
+            recent_window=1001,
+        )


### PR DESCRIPTION
### Motivation
- Provide a short-term (sliding-window) view of training performance so that transient changes are visible alongside the existing epoch-wide running metrics.

### Description
- Add `collections.deque`-backed sliding windows (`maxlen=500`) named `recent_losses` and `recent_accuracies` inside `UNetModel.train` to track the last 500 batch metrics each epoch.
- Compute `recent500_loss` and `recent500_accuracy` and include them in the periodic batch log line written when `batch % 1000 == 0` in `training.log` by extending the existing log message to include these values.
- Update batch bookkeeping to append `batch_loss` and `batch_acc` to both the full-run lists and the new recent deques to keep both global and short-term aggregates.
- Add a unit test `test_train_logs_recent500_metrics_every_1000_batches` that stubs `build_dataloaders_from_h5` with 1000 training batches and asserts the `recent500_*` fields appear in `training.log`.

### Testing
- Added a pytest that stubs dataloaders and verifies `training.log` contains `recent500_loss` and `recent500_accuracy` after running `UNetModel.train` with 1000 synthetic batches (`tests/models/unet/test_unet_model.py::test_train_logs_recent500_metrics_every_1000_batches`).
- Attempted to run `pytest -q tests/models/unet/test_unet_model.py -k recent500`, but collection failed in this environment due to a missing `h5py` dependency, so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd867a4a8c832cb3a4b746f69b09c8)

## Summary by Sourcery

Log additional short-term training metrics for the UNet model and verify their presence in training logs.

New Features:
- Track recent batch losses and accuracies over a sliding window during UNet training and log their 500-batch means periodically.

Tests:
- Add a unit test that runs UNet training with 1000 synthetic batches and asserts the recent500 loss and accuracy metrics are written to training.log.