### PR TITLE
Optimize UNet H5 dataloader dtype conversion and collation churn

### DIFF
--- a/gaishi/models/unet/dataloader_h5.py
+++ b/gaishi/models/unet/dataloader_h5.py
@@ -128,17 +128,18 @@ class H5Dataset(Dataset):
         h5 = self._get_h5()
         r = int(idx) if self.indices is None else int(self.indices[idx])
 
-        ref = np.asarray(h5["/data/Ref_genotype"][r])
-        tgt = np.asarray(h5["/data/Tgt_genotype"][r])
+        ref = np.asarray(h5["/data/Ref_genotype"][r], dtype=self.x_dtype)
+        tgt = np.asarray(h5["/data/Tgt_genotype"][r], dtype=self.x_dtype)
+        if self.channels not in (2, 4):
+            raise ValueError("channels must be 2 or 4")
 
-        if self.channels == 2:
-            x = np.stack([ref, tgt], axis=0)
-        else:
-            gp = np.asarray(h5["/data/Gap_to_prev"][r])
-            gn = np.asarray(h5["/data/Gap_to_next"][r])
-            x = np.stack([ref, tgt, gp, gn], axis=0)
+        x = np.empty((self.channels,) + ref.shape, dtype=self.x_dtype)
+        x[0] = ref
+        x[1] = tgt
 
-        x = x.astype(self.x_dtype, copy=False)
+        if self.channels == 4:
+            x[2] = np.asarray(h5["/data/Gap_to_prev"][r], dtype=self.x_dtype)
+            x[3] = np.asarray(h5["/data/Gap_to_next"][r], dtype=self.x_dtype)
 
         if "/targets/Label" in h5:
             y = np.asarray(h5["/targets/Label"][r])[None, :, :]  # (1,N,L)
@@ -212,13 +213,17 @@ def make_h5_collate_fn(
             if y is not None:
                 ys.append(y)
 
-        x_np = np.stack(xs, axis=0).astype(np.float32, copy=False)  # (B,C,N,L)
+        x_np = np.stack(xs, axis=0)  # (B,C,N,L)
+        if x_np.dtype != np.float32:
+            x_np = x_np.astype(np.float32, copy=False)
         x_out = torch.from_numpy(x_np)
 
         if len(ys) == 0:
             return x_out, None
 
-        y_np = np.stack(ys, axis=0).astype(np.float32, copy=False)  # (B,1,N,L)
+        y_np = np.stack(ys, axis=0)  # (B,1,N,L)
+        if y_np.dtype != np.float32:
+            y_np = y_np.astype(np.float32, copy=False)
 
         if label_smooth:
             e = rng.uniform(0.0, float(label_noise), size=y_np.shape).astype(

--- a/tests/models/unet/test_dataloader_h5.py
+++ b/tests/models/unet/test_dataloader_h5.py
@@ -140,6 +140,18 @@ def test_h5dataset_invalid_channels_raises(h5_with_labels):
         _ = H5Dataset(h5_file=path, channels=3)
 
 
+def test_h5dataset_getitem_rejects_invalid_runtime_channels(h5_with_labels):
+    path, _ = h5_with_labels
+    ds = H5Dataset(h5_file=path, channels=2, require_labels=True)
+    ds.channels = 3
+
+    with pytest.raises(ValueError, match="channels must be 2 or 4"):
+        _ = ds[0]
+
+    if ds._h5 is not None:
+        ds._h5.close()
+
+
 def test_h5dataset_missing_labels_behavior(h5_no_labels):
     path, _ = h5_no_labels
 
@@ -168,6 +180,49 @@ def test_make_h5_collate_fn_no_labels():
     assert xb.dtype == torch.float32
     assert xb.shape == (2, 4, 2, 3)
     assert yb is None
+
+
+def test_make_h5_collate_fn_preserves_float32_input():
+    x = np.zeros((4, 2, 3), dtype=np.float32)
+    y = np.ones((1, 2, 3), dtype=np.float32)
+    batch = [(x, y), (x, y)]
+
+    collate = make_h5_collate_fn(label_smooth=False)
+    xb, yb = collate(batch)
+
+    assert xb.dtype == torch.float32
+    assert yb is not None
+    assert yb.dtype == torch.float32
+    assert xb.shape == (2, 4, 2, 3)
+    assert yb.shape == (2, 1, 2, 3)
+
+
+def test_make_h5_collate_fn_casts_non_float32_inputs():
+    x = np.array(
+        [
+            [[0, 1, 2], [3, 4, 5]],
+            [[6, 7, 8], [9, 10, 11]],
+            [[12, 13, 14], [15, 16, 17]],
+            [[18, 19, 20], [21, 22, 23]],
+        ],
+        dtype=np.int16,
+    )
+    y = np.array([[[0.0, 1.0, 0.5], [1.0, 0.25, 0.75]]], dtype=np.float64)
+    batch = [(x, y), (x, y)]
+
+    collate = make_h5_collate_fn(label_smooth=False)
+    xb, yb = collate(batch)
+
+    assert xb.dtype == torch.float32
+    assert yb is not None
+    assert yb.dtype == torch.float32
+    assert xb.shape == (2, 4, 2, 3)
+    assert yb.shape == (2, 1, 2, 3)
+
+    expected_x = np.stack([x, x], axis=0).astype(np.float32)
+    expected_y = np.stack([y, y], axis=0).astype(np.float32)
+    assert torch.equal(xb, torch.from_numpy(expected_x))
+    assert torch.equal(yb, torch.from_numpy(expected_y))
 
 
 def test_make_h5_collate_fn_label_smoothing_exact():


### PR DESCRIPTION
### Motivation
- Reduce redundant dtype conversions and intermediate array churn in the UNet HDF5 data path to lower CPU and memory overhead while preserving existing shapes and semantics (`x: (C,N,L)`, `y: (1,N,L)`).

### Description
- In `H5Dataset.__getitem__` read datasets with `dtype=self.x_dtype`, preallocate `x = np.empty((self.channels,) + ref.shape, dtype=self.x_dtype)`, and fill channels in-place to avoid an extra `np.stack(...).astype(...)` allocation.
- In `make_h5_collate_fn` stack sample arrays and only call `.astype(np.float32, copy=False)` when the stacked result is not already `float32`, avoiding unconditional casts for already-correct dtypes.
- Add test `test_make_h5_collate_fn_preserves_float32_input` to assert collate preserves dtype and shape when inputs are already `float32`.
- No public interfaces were changed and original `(C,N,L)` / `(1,N,L)` semantics are preserved.

### Testing
- Ran `pytest tests/models/unet/test_dataloader_h5.py -q`, which failed in this environment during collection with `ModuleNotFoundError: No module named 'h5py'` so tests could not be executed here.
- Ran `flake8 gaishi/models/unet/dataloader_h5.py`, which failed in this environment because the `flake8` binary is not available.
- The new test was added and the code committed; please run CI or local test commands with `h5py` and `flake8` available to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd3baebb8832c82fc6553455807db)

## Summary by Sourcery

Optimize the UNet HDF5 dataloader to reduce redundant dtype conversions and intermediate allocations while preserving existing tensor shapes and semantics.

Enhancements:
- Preallocate UNet HDF5 feature tensors and load channel data directly with the target dtype to avoid extra stacking and casting.
- Update the HDF5 collate function to conditionally cast to float32 only when necessary, reducing unnecessary copies.

Tests:
- Add a collate function test to verify that float32 inputs preserve dtype and expected batch shapes.