### PR TITLE
Rename recent500 to recent_500 in UNet

### DIFF
--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -335,8 +335,8 @@ class UNetModel(MlModel):
                     training_log_file.write(
                         f"Epoch {epoch_idx}, batch {batch_idx}: "
                         f"loss = {mean_loss}, accuracy = {mean_acc}, "
-                        f"recent{recent_window}_loss = {recent_loss}, "
-                        f"recent{recent_window}_accuracy = {recent_acc}.\n"
+                        f"recent_{recent_window}_loss = {recent_loss}, "
+                        f"recent_{recent_window}_accuracy = {recent_acc}.\n"
                     )
                     training_log_file.flush()
 

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -821,12 +821,12 @@ def test_train_uses_dataloader_worker_perf_defaults_when_none(tmp_path, monkeypa
     assert "prefetch_factor" not in captured
 
 
-def test_train_logs_recent500_metrics_every_1000_batches(tmp_path, monkeypatch):
+def test_train_logs_recent_500_metrics_every_1000_batches(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)
 
     training_data = _make_training_h5(tmp_path, n_reps=20, N=2, L=7, with_gaps=True)
-    model_dir = tmp_path / "model_out_recent500"
+    model_dir = tmp_path / "model_out_recent_500"
     model_path = model_dir / "best.safetensors"
 
     xb = torch.zeros((1, 2, 2, 7), dtype=torch.float32)
@@ -852,8 +852,8 @@ def test_train_logs_recent500_metrics_every_1000_batches(tmp_path, monkeypatch):
     )
 
     training_log_text = (model_dir / "training.log").read_text()
-    assert "recent500_loss =" in training_log_text
-    assert "recent500_accuracy =" in training_log_text
+    assert "recent_500_loss =" in training_log_text
+    assert "recent_500_accuracy =" in training_log_text
 
 
 def test_train_logs_recent_window_metrics_with_custom_window(tmp_path, monkeypatch):
@@ -890,8 +890,8 @@ def test_train_logs_recent_window_metrics_with_custom_window(tmp_path, monkeypat
     )
 
     training_log_text = (model_dir / "training.log").read_text()
-    assert "recent123_loss =" in training_log_text
-    assert "recent123_accuracy =" in training_log_text
+    assert "recent_123_loss =" in training_log_text
+    assert "recent_123_accuracy =" in training_log_text
 
 
 def test_train_raises_for_recent_window_greater_than_1000(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Standardize metric naming in UNet training logs and tests by replacing `recent500` with `recent_500` for readability and consistency.

### Description
- Updated `tests/models/unet/test_unet_model.py` to rename the test to `test_train_logs_recent_500_metrics_every_1000_batches`, change the temporary output dir to `model_out_recent_500`, and update assertions to expect `recent_500_loss` and `recent_500_accuracy` in the training log.

### Testing
- Ran `pytest -q tests/models/unet/test_unet_model.py -k recent_500`, which failed during collection due to a missing dependency (`h5py`) in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf1af444c832c8d2605fa8a486043)

## Summary by Sourcery

Enhancements:
- Rename the UNet training log test, output directory, and asserted metric keys from `recent500` to `recent_500` for consistency with the updated metric naming.