### PR TITLE
Stop UNet training loop when early-stopping patience is reached

### DIFF
--- a/gaishi/models/unet/unet_model.py
+++ b/gaishi/models/unet/unet_model.py
@@ -293,6 +293,7 @@ class UNetModel(MlModel):
         min_val_loss = np.inf
         early_count = 0
         best_epoch = 0
+        is_early_stop = False
 
         for epoch_idx in range(1, int(n_epochs) + 1):
             net.train()
@@ -371,13 +372,17 @@ class UNetModel(MlModel):
                 early_count = 0
             else:
                 early_count += 1
-                if early_count >= int(n_early):
+                if int(n_early) > 0 and early_count >= int(n_early):
                     add_msg = (
                         f" Early stopping; best weights at epoch {best_epoch} reloaded."
                     )
                     net.load_state_dict(load_file(output, device="cpu"))
+                    is_early_stop = True
             validation_log_file.write(log_msg + add_msg + "\n")
             validation_log_file.flush()
+
+            if is_early_stop:
+                break
 
         training_log_file.flush()
         training_log_file.close()

--- a/tests/models/unet/test_unet_model.py
+++ b/tests/models/unet/test_unet_model.py
@@ -219,6 +219,37 @@ def test_train_branch_neighbor_gap_fusion_four_channel(tmp_path, monkeypatch):
     assert DummyUNetPlusPlusRNN.last_init["polymorphisms"] == 11
 
 
+def test_train_stops_when_early_stopping_is_triggered(tmp_path, monkeypatch):
+    class ConstantLoss(torch.nn.Module):
+        def forward(self, y_pred, y_true):
+            return y_pred.mean() * 0 + torch.tensor(
+                1.0, device=y_pred.device, dtype=y_pred.dtype
+            )
+
+    monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
+    monkeypatch.setattr(unet_mod, "BCEWithLogitsLoss", lambda **kwargs: ConstantLoss())
+
+    training_data = _make_training_h5(tmp_path, n_reps=40, N=2, L=7, with_gaps=True)
+    model_dir = tmp_path / "model_out_early_stop"
+    model_path = model_dir / "best.safetensors"
+
+    unet_mod.UNetModel.train(
+        data=training_data,
+        output=str(model_path),
+        add_rnn=False,
+        batch_size=2,
+        n_early=1,
+        n_epochs=5,
+        min_delta=0.0,
+        val_prop=0.2,
+        seed=0,
+    )
+
+    val_lines = (model_dir / "validation.log").read_text().strip().splitlines()
+    assert len(val_lines) == 2
+    assert "Early stopping; best weights at epoch 1 reloaded." in val_lines[-1]
+
+
 def test_train_raises_when_add_rnn_true_but_missing_gap_datasets(tmp_path, monkeypatch):
     monkeypatch.setattr(unet_mod, "UNetPlusPlus", DummyUNetPlusPlus)
     monkeypatch.setattr(unet_mod, "UNetPlusPlusRNN", DummyUNetPlusPlusRNN)


### PR DESCRIPTION
### Motivation
- The training loop for `UNetModel.train` reloaded the best checkpoint when early stopping was triggered but did not exit the epoch loop, allowing training to continue despite patience being reached.

### Description
- Added a break after the validation logging so that when `early_count >= int(n_early)` the epoch loop is exited and training stops while preserving the existing behavior of reloading the best weights (`gaishi/models/unet/unet_model.py`).
- Added a regression test `test_train_stops_when_early_stopping_is_triggered` that forces a constant validation loss and verifies training exits after early stopping is triggered by inspecting `validation.log` (`tests/models/unet/test_unet_model.py`).

### Testing
- Added unit test `tests/models/unet/test_unet_model.py::test_train_stops_when_early_stopping_is_triggered` and attempted to run it with `pytest -q tests/models/unet/test_unet_model.py -k early_stopping_is_triggered`, but test collection failed in this environment due to a missing dependency (`h5py`).
- The code change is minimal and the new test asserts that `validation.log` contains the early stopping message and that the number of validation log lines matches the expected stopped epoch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef6687f44832cac0257ceee374c9f)

## Summary by Sourcery

Stop UNet training when early-stopping patience is reached and guard against regressions.

Bug Fixes:
- Ensure the UNet training loop exits the epoch loop once the early-stopping patience threshold is reached while still reloading the best weights.

Tests:
- Add a regression test that forces constant validation loss and verifies training stops after early stopping is triggered by inspecting the validation log.