### PR TITLE
Relax Pydantic strictness and replace Strict types with native annotations in model_config

### DIFF
--- a/gaishi/configs/model_config.py
+++ b/gaishi/configs/model_config.py
@@ -20,7 +20,7 @@
 import inspect
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic import model_validator
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.linear_model import LogisticRegression
@@ -31,9 +31,9 @@ class LrParams(BaseModel):
     Parameter schema for logistic regression model configuration.
     """
 
-    model_config = ConfigDict(extra="allow", strict=True)
+    model_config = ConfigDict(extra="allow")
 
-    is_scaled: StrictBool = False
+    is_scaled: bool = False
 
     @model_validator(mode="after")
     def validate_known_keys(self) -> "LrParams":
@@ -54,9 +54,9 @@ class EtcParams(BaseModel):
     Parameter schema for extra-trees classifier model configuration.
     """
 
-    model_config = ConfigDict(extra="allow", strict=True)
+    model_config = ConfigDict(extra="allow")
 
-    is_scaled: StrictBool = False
+    is_scaled: bool = False
 
     @model_validator(mode="after")
     def validate_known_keys(self) -> "EtcParams":
@@ -77,33 +77,33 @@ class UnetParams(BaseModel):
     Strict parameter schema for the UNet++ model.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True)
+    model_config = ConfigDict(extra="forbid")
 
     trained_model_file: Optional[str] = None
-    add_rnn: StrictBool = False
-    site_weighting: StrictBool = False
-    batch_size: StrictInt = Field(default=32, gt=0)
-    n_early: StrictInt = Field(default=10, gt=0)
-    n_epochs: StrictInt = Field(default=100, gt=0)
-    learning_rate: StrictFloat = Field(default=0.001, gt=0)
-    min_delta: StrictFloat = Field(default=1e-4, gt=0)
-    val_prop: StrictFloat = Field(default=0.05, gt=0, lt=1)
-    seed: Optional[StrictInt] = None
+    add_rnn: bool = False
+    site_weighting: bool = False
+    batch_size: int = Field(default=32, gt=0)
+    n_early: int = Field(default=10, gt=0)
+    n_epochs: int = Field(default=100, gt=0)
+    learning_rate: float = Field(default=0.001, gt=0)
+    min_delta: float = Field(default=1e-4, gt=0)
+    val_prop: float = Field(default=0.05, gt=0, lt=1)
+    seed: Optional[int] = None
     device: Optional[str] = None
-    num_workers: StrictInt = Field(default=0, ge=0)
-    train_drop_last: Optional[StrictBool] = None
-    val_drop_last: Optional[StrictBool] = None
-    persistent_workers: Optional[StrictBool] = None
-    prefetch_factor: Optional[StrictInt] = Field(default=None, gt=0)
-    use_amp: StrictBool = False
-    recent_window: StrictInt = Field(default=500, ge=1, le=1000)
+    num_workers: int = Field(default=0, ge=0)
+    train_drop_last: Optional[bool] = None
+    val_drop_last: Optional[bool] = None
+    persistent_workers: Optional[bool] = None
+    prefetch_factor: Optional[int] = Field(default=None, gt=0)
+    use_amp: bool = False
+    recent_window: int = Field(default=500, ge=1, le=1000)
 
 
 class ModelConfig(BaseModel):
     name: Literal["logistic_regression", "extra_trees_classifier", "unet++"]
     params: dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="forbid", strict=True)
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
     def validate_params_by_model_name(self) -> "ModelConfig":


### PR DESCRIPTION
### Motivation
- Make the Pydantic model definitions simpler and compatible with newer Pydantic usages by removing deprecated/strict options and `Strict*` type aliases. 
- Reduce verbosity of type annotations while preserving field constraints and runtime validation of unknown parameters.

### Description
- Removed import and usage of `StrictBool`, `StrictFloat`, and `StrictInt` and replaced those annotations with native `bool`, `float`, and `int` in `LrParams`, `EtcParams`, and `UnetParams`.
- Dropped `strict=True` from `model_config = ConfigDict(...)` in multiple models and kept the `extra` policy adjustments (`"allow"` or `"forbid"`) as before.
- Kept existing `@model_validator` logic that checks extra keys against the underlying estimator signatures and preserved `Field` constraints such as `gt`, `ge`, and `le` for numeric fields.
- Updated `ModelConfig` to continue mapping `name` to per-model schemas and to dump/merge `params` via `model_dump` and `model_extra` as before.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034e98c61c832c8ec779ef685e2b32)

## Summary by Sourcery

Relax Pydantic model strictness for selected model parameter schemas while preserving existing validation behavior.

Enhancements:
- Replace deprecated StrictBool/StrictInt/StrictFloat annotations with native bool/int/float in logistic regression, extra-trees classifier, and UNet++ parameter models.
- Remove strict=True from ConfigDict in parameter and model config schemas while keeping existing extra-field policies intact.