### PR TITLE
Relax pydantic strict validation in model configs and update tests

### DIFF
--- a/gaishi/configs/model_config.py
+++ b/gaishi/configs/model_config.py
@@ -20,7 +20,7 @@
 import inspect
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic import model_validator
 from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.linear_model import LogisticRegression
@@ -31,9 +31,9 @@ class LrParams(BaseModel):
     Parameter schema for logistic regression model configuration.
     """
 
-    model_config = ConfigDict(extra="allow", strict=True)
+    model_config = ConfigDict(extra="allow")
 
-    is_scaled: StrictBool = False
+    is_scaled: bool = False
 
     @model_validator(mode="after")
     def validate_known_keys(self) -> "LrParams":
@@ -54,9 +54,9 @@ class EtcParams(BaseModel):
     Parameter schema for extra-trees classifier model configuration.
     """
 
-    model_config = ConfigDict(extra="allow", strict=True)
+    model_config = ConfigDict(extra="allow")
 
-    is_scaled: StrictBool = False
+    is_scaled: bool = False
 
     @model_validator(mode="after")
     def validate_known_keys(self) -> "EtcParams":
@@ -77,33 +77,33 @@ class UnetParams(BaseModel):
     Strict parameter schema for the UNet++ model.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True)
+    model_config = ConfigDict(extra="forbid")
 
     trained_model_file: Optional[str] = None
-    add_rnn: StrictBool = False
-    site_weighting: StrictBool = False
-    batch_size: StrictInt = Field(default=32, gt=0)
-    n_early: StrictInt = Field(default=10, gt=0)
-    n_epochs: StrictInt = Field(default=100, gt=0)
-    learning_rate: StrictFloat = Field(default=0.001, gt=0)
-    min_delta: StrictFloat = Field(default=1e-4, gt=0)
-    val_prop: StrictFloat = Field(default=0.05, gt=0, lt=1)
-    seed: Optional[StrictInt] = None
+    add_rnn: bool = False
+    site_weighting: bool = False
+    batch_size: int = Field(default=32, gt=0)
+    n_early: int = Field(default=10, gt=0)
+    n_epochs: int = Field(default=100, gt=0)
+    learning_rate: float = Field(default=0.001, gt=0)
+    min_delta: float = Field(default=1e-4, gt=0)
+    val_prop: float = Field(default=0.05, gt=0, lt=1)
+    seed: Optional[int] = None
     device: Optional[str] = None
-    num_workers: StrictInt = Field(default=0, ge=0)
-    train_drop_last: Optional[StrictBool] = None
-    val_drop_last: Optional[StrictBool] = None
-    persistent_workers: Optional[StrictBool] = None
-    prefetch_factor: Optional[StrictInt] = Field(default=None, gt=0)
-    use_amp: StrictBool = False
-    recent_window: StrictInt = Field(default=500, ge=1, le=1000)
+    num_workers: int = Field(default=0, ge=0)
+    train_drop_last: Optional[bool] = None
+    val_drop_last: Optional[bool] = None
+    persistent_workers: Optional[bool] = None
+    prefetch_factor: Optional[int] = Field(default=None, gt=0)
+    use_amp: bool = False
+    recent_window: int = Field(default=500, ge=1, le=1000)
 
 
 class ModelConfig(BaseModel):
     name: Literal["logistic_regression", "extra_trees_classifier", "unet++"]
     params: dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="forbid", strict=True)
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
     def validate_params_by_model_name(self) -> "ModelConfig":

--- a/tests/configs/test_model_config.py
+++ b/tests/configs/test_model_config.py
@@ -103,10 +103,6 @@ def test_model_config_unknown_param_unet_plusplus_raises():
         )
 
 
-def test_model_config_strict_mode_rejects_type_coercion():
-    with pytest.raises(ValidationError):
-        ModelConfig(name="unet++", params={"batch_size": "16"})
-
 
 def test_model_config_unet_boundaries_are_enforced():
     with pytest.raises(ValidationError):


### PR DESCRIPTION
### Motivation
- Remove strict pydantic-only types and `strict=True` flags to relax type coercion and simplify compatibility with newer pydantic usage. 
- Align tests with the relaxed validation behavior by removing the assertion that string-to-number coercion is rejected.

### Description
- Removed `StrictBool`, `StrictInt`, and `StrictFloat` imports and replaced field annotations with built-in types such as `bool`, `int`, and `float` in `LrParams`, `EtcParams`, and `UnetParams`.
- Removed `strict=True` from `ConfigDict` usage and kept `extra` settings unchanged where appropriate in `LrParams`, `EtcParams`, `UnetParams`, and `ModelConfig`.
- Kept the per-model validation flow in `ModelConfig` unchanged, still using the strict per-model schema classes to validate and normalize `params`.
- Updated tests by deleting `test_model_config_strict_mode_rejects_type_coercion` to reflect the relaxed coercion policy.

### Testing
- Ran `pytest tests/configs/test_model_config.py` and the modified test file passed.
- Existing validation tests for unknown params and boundary checks continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034e98c61c832c8ec779ef685e2b32)

## Summary by Sourcery

Relax strict Pydantic validation in model parameter configs and align tests with the new coercion behavior.

Enhancements:
- Allow non-strict type coercion in logistic regression, extra-trees, and UNet++ parameter schemas by using standard Python types and removing strict mode from their ConfigDicts.
- Relax strict validation on the top-level ModelConfig schema while preserving existing per-model validation logic.

Tests:
- Remove the test asserting rejection of string-to-number coercion to reflect the relaxed type coercion policy in model configs.