### PR TITLE
Make subparsers required in main parser

### DIFF
--- a/gaishi/__main__.py
+++ b/gaishi/__main__.py
@@ -51,6 +51,8 @@ def _gaishi_cli_parser() -> argparse.ArgumentParser:
     )
     top_parser.add_argument("--version", action="version", version=f"{__version__}")
     subparsers = top_parser.add_subparsers(dest="subparsers")
+    subparsers.required = True
+    
     add_train_parser(subparsers)
     add_infer_parser(subparsers)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enforce that a subparser (subcommand) must be provided when calling the top-level CLI parser, improving argument validation and user feedback.