### PR TITLE
Fix typo in global_config.py docstring

### DIFF
--- a/gaishi/configs/global_config.py
+++ b/gaishi/configs/global_config.py
@@ -38,7 +38,7 @@ PreprocessConfigUnion = Annotated[
 
 class GlobalConfig(BaseModel):
     """
-    Top-level config for runing gaishi
+    Top-level config for running gaishi
 
     - training: simulation + model details.
     - infer: preprocess + model details.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the spelling of 'running' in the GlobalConfig docstring description.