### PR TITLE
Remove LR/ETC scaler sidecar handling

### DIFF
--- a/gaishi/configs/model_config.py
+++ b/gaishi/configs/model_config.py
@@ -33,15 +33,12 @@ class LrParams(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    is_scaled: bool = False
-
     @model_validator(mode="after")
     def validate_known_keys(self) -> "LrParams":
         """
-        Validate keys against LogisticRegression signature plus gaishi-specific keys.
+        Validate keys against LogisticRegression signature.
         """
         allowed_keys = set(inspect.signature(LogisticRegression).parameters)
-        allowed_keys.add("is_scaled")
         unknown_keys = set(self.model_extra or {}).difference(allowed_keys)
         if unknown_keys:
             unknown_str = ", ".join(sorted(unknown_keys))
@@ -56,15 +53,12 @@ class EtcParams(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    is_scaled: bool = False
-
     @model_validator(mode="after")
     def validate_known_keys(self) -> "EtcParams":
         """
-        Validate keys against ExtraTreesClassifier signature plus gaishi-specific keys.
+        Validate keys against ExtraTreesClassifier signature.
         """
         allowed_keys = set(inspect.signature(ExtraTreesClassifier).parameters)
-        allowed_keys.add("is_scaled")
         unknown_keys = set(self.model_extra or {}).difference(allowed_keys)
         if unknown_keys:
             unknown_str = ", ".join(sorted(unknown_keys))

--- a/gaishi/models/etc_model.py
+++ b/gaishi/models/etc_model.py
@@ -20,7 +20,6 @@
 import inspect, joblib, os
 import pandas as pd
 from sklearn.ensemble import ExtraTreesClassifier
-from sklearn.preprocessing import StandardScaler
 from gaishi.models import MlModel
 from gaishi.registries.model_registry import MODEL_REGISTRY
 
@@ -48,11 +47,7 @@ class EtcModel(MlModel):
         The input feature table is read from a tab-separated file, a model is
         fitted, and the trained model is written to disk. Any keyword arguments
         in `model_params` are forwarded to the underlying
-        :class:`sklearn.ensemble.ExtraTreesClassifier`. If data scaling is
-        enabled (e.g. via an `is_scaled` flag in `model_params`), the feature
-        matrix is scaled using :class:`sklearn.preprocessing.StandardScaler`
-        and the fitted scaler is saved alongside the model file.
-
+        :class:`sklearn.ensemble.ExtraTreesClassifier`.
         Parameters
         ----------
         data : str
@@ -65,8 +60,6 @@ class EtcModel(MlModel):
             Additional keyword arguments controlling the model and optional
             preprocessing. These are passed to the underlying extra-trees
             classifier (for example `n_estimators`, `max_depth`, `random_state`)
-            and may also include flags such as `is_scaled` to indicate that
-            the feature data should be standardized before training.
         """
         features = pd.read_csv(data, sep="\t")
 
@@ -78,11 +71,6 @@ class EtcModel(MlModel):
         data = features.drop(
             columns=["Chromosome", "Start", "End", "Sample", "Replicate", "Label"]
         ).values
-
-        if "is_scaled" in model_params and model_params["is_scaled"]:
-            scaler = StandardScaler()
-            data = scaler.fit_transform(data)
-            joblib.dump(scaler, f"{output}.scaler")
 
         is_allowed = inspect.signature(ExtraTreesClassifier).parameters
         clean_params = {k: v for k, v in model_params.items() if k in is_allowed}
@@ -104,11 +92,8 @@ class EtcModel(MlModel):
 
         The feature table is read from a tab-separated file, the trained model is
         loaded from disk, and predictions are written to the specified output.
-        Any keyword arguments in `model_params` are forwarded to the underlying
-        :class:`sklearn.ensemble.ExtraTreesClassifier` or used to control
-        optional preprocessing. If an `is_scaled` flag is provided and set to
-        True, a scaler object is loaded from `<model>.scaler` and applied to
-        the feature matrix before inference.
+        Any keyword arguments in `model_params` are accepted for API compatibility
+        and ignored during inference.
 
         Parameters
         ----------
@@ -118,19 +103,12 @@ class EtcModel(MlModel):
             data, along with any metadata columns that will be dropped before
             prediction.
         model : str
-            Path to the saved trained model (e.g. a joblib pickle). If
-            `is_scaled=True` is passed via `model_params`, the method will
-            also look for a corresponding scaler file at `<model>.scaler` and
-            apply it to the features.
+            Path to the saved trained model (e.g. a joblib pickle).
         output : str
             Path where the inference output (e.g. predicted labels or
             probabilities) will be written.
         **model_params
-            Additional keyword arguments controlling the model and optional
-            preprocessing. These are typically forwarded to the underlying
-            extra-trees classifier (for example `n_jobs`, `random_state`) and
-            may include an `is_scaled` flag indicating that a saved scaler
-            should be loaded and applied prior to prediction.
+            Additional keyword arguments accepted for API compatibility.
         """
         features = pd.read_csv(data, sep="\t")
         output_dir = os.path.dirname(output)
@@ -138,18 +116,6 @@ class EtcModel(MlModel):
             os.makedirs(output_dir, exist_ok=True)
 
         data = features.drop(columns=["Chromosome", "Start", "End", "Sample"]).values
-
-        if "is_scaled" in model_params and model_params["is_scaled"]:
-            scaler_path = f"{model}.scaler"
-            try:
-                scaler = joblib.load(scaler_path)
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"Scaler file not found: {scaler_path}. Please ensure the scaler was saved during training."
-                )
-            except Exception as e:
-                raise RuntimeError(f"Failed to load scaler from {scaler_path}: {e}")
-            data = scaler.transform(data)
 
         model = joblib.load(model)
 

--- a/gaishi/models/lr_model.py
+++ b/gaishi/models/lr_model.py
@@ -20,7 +20,6 @@
 import inspect, joblib, os
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
-from sklearn.preprocessing import StandardScaler
 from gaishi.models import MlModel
 from gaishi.registries.model_registry import MODEL_REGISTRY
 
@@ -48,11 +47,7 @@ class LrModel(MlModel):
         The input feature table is read from a tab-separated file, a model is
         fitted, and the trained model is written to disk. Any keyword arguments
         in `model_params` are forwarded to the underlying
-        :class:`sklearn.linear_model.LogisticRegression`. If data scaling is
-        enabled (e.g. via an `is_scaled` flag in `model_params`), the feature
-        matrix is scaled using :class:`sklearn.preprocessing.StandardScaler`
-        and the fitted scaler is saved alongside the model file.
-
+        :class:`sklearn.linear_model.LogisticRegression`.
         Parameters
         ----------
         data : str
@@ -63,8 +58,6 @@ class LrModel(MlModel):
             Additional keyword arguments controlling the model and optional
             preprocessing. These are passed to the underlying logistic regression
             model (for example `solver`, `penalty`, `max_iter`)
-            and may also include flags such as `is_scaled` to indicate that
-            the feature data should be standardized before training.
         """
         features = pd.read_csv(data, sep="\t")
 
@@ -72,11 +65,6 @@ class LrModel(MlModel):
         data = features.drop(
             columns=["Chromosome", "Start", "End", "Sample", "Replicate", "Label"]
         ).values
-
-        if "is_scaled" in model_params and model_params["is_scaled"]:
-            scaler = StandardScaler()
-            data = scaler.fit_transform(data)
-            joblib.dump(scaler, f"{output}.scaler")
 
         is_allowed = inspect.signature(LogisticRegression).parameters
         clean_params = {k: v for k, v in model_params.items() if k in is_allowed}
@@ -98,45 +86,25 @@ class LrModel(MlModel):
 
         The feature table is read from a tab-separated file, the trained model is
         loaded from disk, and predictions are written to the specified output.
-        Any keyword arguments in `model_params` are forwarded to the underlying
-        :class:`sklearn.linear_model.LogisticRegression` or used to control
-        optional preprocessing. If an `is_scaled` flag is provided and set to
-        True, a scaler object is loaded from `<model>.scaler` and applied to
-        the feature matrix before inference.
+        Any keyword arguments in `model_params` are accepted for API compatibility
+        and ignored during inference.
 
         Parameters
         ----------
         data : str
             Path to the inference data file in tab-separated format.
         model : str
-            Path to the saved trained model. The method will also look for `<model_file>.scaler`
-            if `is_scaled` is True to load and apply the scaler.
+            Path to the saved trained model.
         output : str
             Path where the inference output will be saved.
         **model_params
-            Additional keyword arguments controlling the model and optional
-            preprocessing. These are typically forwarded to the underlying
-            logsitic regression model (for example `solver`, `random_state`) and
-            may include an `is_scaled` flag indicating that a saved scaler
-            should be loaded and applied prior to prediction.
+            Additional keyword arguments accepted for API compatibility.
         """
         features = pd.read_csv(data, sep="\t")
         output_dir = os.path.dirname(output)
         os.makedirs(output_dir, exist_ok=True)
 
         data = features.drop(columns=["Chromosome", "Start", "End", "Sample"]).values
-
-        if "is_scaled" in model_params and model_params["is_scaled"]:
-            scaler_path = f"{model}.scaler"
-            try:
-                scaler = joblib.load(scaler_path)
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"Scaler file not found: {scaler_path}. Please ensure the scaler was saved during training."
-                )
-            except Exception as e:
-                raise RuntimeError(f"Failed to load scaler from {scaler_path}: {e}")
-            data = scaler.transform(data)
 
         model = joblib.load(model)
 

--- a/tests/configs/test_model_config.py
+++ b/tests/configs/test_model_config.py
@@ -79,7 +79,7 @@ def test_model_config_extra_top_level_field_forbidden():
 
 def test_model_config_params_default_is_empty_dict():
     cfg = ModelConfig(name="logistic_regression")
-    assert cfg.params == {"is_scaled": False}
+    assert cfg.params == {}
 
 
 def test_model_config_unknown_param_raises():


### PR DESCRIPTION
### Motivation

- Stop producing and consuming `{output}.scaler` sidecar artifacts for the logistic regression and extra-trees models while preserving existing training/inference semantics. 

### Description

- Removed scaler creation and `joblib.dump(... .scaler)` from `LrModel.train` and `EtcModel.train` so training only saves the model artifact. 
- Removed scaler lookup/load/transform code paths from `LrModel.infer` and `EtcModel.infer` so inference no longer searches for or loads `<model>.scaler`. 
- Updated docstrings to remove references to scaler sidecars and clarified that extra `model_params` are accepted for API compatibility. 
- Updated tests `tests/models/test_lr_model.py` and `tests/models/test_etc_model.py` to pass `is_scaled=True` (to ensure backward-compatible call sites remain valid) and to assert that no `{training_output}.scaler` file is produced. 

### Testing

- Ran formatting with `black` on the modified files, which completed successfully. 
- Attempted to run `flake8` but the command is not available in the execution environment so linting could not be completed. 
- Ran `pytest -q tests/models/test_lr_model.py tests/models/test_etc_model.py tests/test_train.py`, which failed at test collection due to `ModuleNotFoundError: No module named 'joblib'` in the environment, so the updated tests could not be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f54a1ddc832c8593ef4c88b552d3)

## Summary by Sourcery

Remove scaler sidecar handling from logistic regression and extra-trees models while keeping the public training and inference APIs compatible.

Bug Fixes:
- Stop relying on separate scaler artifacts during training and inference for logistic regression and extra-trees models.

Enhancements:
- Simplify LrModel and EtcModel to train and infer directly on input features without saving or loading StandardScaler sidecar files.
- Clarify model docstrings to no longer describe scaler behavior while noting that extra model_params are accepted but ignored at inference time.

Tests:
- Update LR and ETC model tests to call train/infer with is_scaled for backward compatibility and assert that no .scaler artifact is created.