### PR TITLE
Rename top-level `preprocess` config to `preprocessing` and update references

### DIFF
--- a/gaishi/configs/global_config.py
+++ b/gaishi/configs/global_config.py
@@ -41,7 +41,7 @@ class GlobalConfig(BaseModel):
     Top-level config for running gaishi
 
     - training: simulation + model details.
-    - infer: preprocess + model details.
+    - infer: preprocessing + model details.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -49,8 +49,8 @@ class GlobalConfig(BaseModel):
     # Simulation block
     simulation: SimulationConfigUnion
 
-    # Preprocess block
-    preprocess: PreprocessConfigUnion
+    # Preprocessing block
+    preprocessing: PreprocessConfigUnion
 
     # Model choice
     model: ModelConfig

--- a/gaishi/infer.py
+++ b/gaishi/infer.py
@@ -51,18 +51,18 @@ def infer(
         raise ValueError(f"Error parsing YAML configuration file '{config}': {e}")
 
     global_config = GlobalConfig(**config_dict)
-    if global_config.preprocess.process_type == "feature_vector":
+    if global_config.preprocessing.process_type == "feature_vector":
         preprocess_feature_vectors(
-            **global_config.preprocess.model_dump(),
+            **global_config.preprocessing.model_dump(),
         )
 
-        data = f"{global_config.preprocess.output_dir}/{global_config.preprocess.output_prefix}.features"
-    elif global_config.preprocess.process_type == "genotype_matrix":
+        data = f"{global_config.preprocessing.output_dir}/{global_config.preprocessing.output_prefix}.features"
+    elif global_config.preprocessing.process_type == "genotype_matrix":
         preprocess_genotype_matrices(
-            **global_config.preprocess.model_dump(),
+            **global_config.preprocessing.model_dump(),
         )
 
-        data = f"{global_config.preprocess.output_dir}/{global_config.preprocess.output_prefix}.h5"
+        data = f"{global_config.preprocessing.output_dir}/{global_config.preprocessing.output_prefix}.h5"
     else:
         raise ValueError("")
 

--- a/tests/configs/test_global_config.py
+++ b/tests/configs/test_global_config.py
@@ -97,7 +97,7 @@ def test_global_config_valid_with_logistic_regression():
 
     cfg = GlobalConfig(
         simulation=sim_cfg,
-        preprocess=preprocess_cfg,
+        preprocessing=preprocess_cfg,
         model=model_cfg,
     )
 
@@ -105,10 +105,10 @@ def test_global_config_valid_with_logistic_regression():
     assert cfg.simulation.nrep == 10
     assert cfg.simulation.seq_len == 1_000_000
 
-    # preprocess block
-    assert cfg.preprocess.chr_name == "chr1"
-    assert isinstance(cfg.preprocess.vcf_file, Path)
-    assert cfg.preprocess.win_len == 10000
+    # preprocessing block
+    assert cfg.preprocessing.chr_name == "chr1"
+    assert isinstance(cfg.preprocessing.vcf_file, Path)
+    assert cfg.preprocessing.win_len == 10000
 
     # model block
     assert cfg.model.name == "logistic_regression"
@@ -122,7 +122,7 @@ def test_global_config_valid_with_extra_trees():
 
     cfg = GlobalConfig(
         simulation=sim_cfg,
-        preprocess=preprocess_cfg,
+        preprocessing=preprocess_cfg,
         model=model_cfg,
     )
 
@@ -137,12 +137,12 @@ def test_global_config_missing_simulation_raises():
 
     with pytest.raises(ValidationError):
         GlobalConfig(
-            preprocess=preprocess_cfg,
+            preprocessing=preprocess_cfg,
             model=model_cfg,
         )  # type: ignore[arg-type]
 
 
-def test_infer_config_missing_preprocess_raises():
+def test_infer_config_missing_preprocessing_raises():
     sim_cfg = FeatureVectorSimulationConfig(**_valid_simulation_kwargs())
     model_cfg = _valid_model_config_logreg()
 
@@ -160,7 +160,7 @@ def test_global_config_missing_model_type_raises():
     with pytest.raises(ValidationError):
         GlobalConfig(
             simulation=sim_cfg,
-            preprocess=preprocess_cfg,
+            preprocessing=preprocess_cfg,
         )  # type: ignore[arg-type]
 
 
@@ -171,7 +171,7 @@ def test_global_config_invalid_model_name_raises():
     with pytest.raises(ValidationError):
         GlobalConfig(
             simulation=sim_cfg,
-            preprocess=preprocess_cfg,
+            preprocessing=preprocess_cfg,
             model=ModelConfig(
                 name="random_forest",  # not allowed by Literal
                 params={"n_estimators": 100},
@@ -202,7 +202,7 @@ def test_global_config_simulation_discriminates_feature_vector():
             "output_dir": Path("results/train"),
             "seed": 42,
         },
-        preprocess=FeatureVectorPreprocessConfig(**_valid_preprocess_kwargs()),
+        preprocessing=FeatureVectorPreprocessConfig(**_valid_preprocess_kwargs()),
         model=_valid_model_config_logreg(),
     )
 
@@ -231,7 +231,7 @@ def test_global_config_simulation_discriminates_genotype_matrix():
             "output_dir": Path("results/train"),
             "seed": 42,
         },
-        preprocess=FeatureVectorPreprocessConfig(**_valid_preprocess_kwargs()),
+        preprocessing=FeatureVectorPreprocessConfig(**_valid_preprocess_kwargs()),
         model=_valid_model_config_logreg(),
     )
 

--- a/tests/data/test.config.yaml
+++ b/tests/data/test.config.yaml
@@ -22,7 +22,7 @@ simulation:
   nprocess: 2
   seed: 12345
 
-preprocess:
+preprocessing:
   process_type: "feature_vector"
   vcf_file: "tests/expected_results/simulators/MsprimeSimulator/0/test.0.vcf"
   chr_name: "1"


### PR DESCRIPTION
### Motivation
- Standardize the top-level configuration key name to better reflect that this block performs preprocessing rather than a verb-like "preprocess" action.
- Align code, tests, and example YAML so that the `GlobalConfig` attribute matches the YAML key and improves clarity when invoking inference.

### Description
- Rename the `GlobalConfig` field from `preprocess` to `preprocessing` and update the class docstring to reference `infer: preprocessing + model details`.
- Update `infer.py` to use `global_config.preprocessing` everywhere and to construct the `data` paths from `preprocessing.output_dir`/`output_prefix`.
- Update unit tests in `tests/configs/test_global_config.py` to use `preprocessing` and adjust a test function name accordingly.
- Update the example test YAML `tests/data/test.config.yaml` to use the `preprocessing` top-level key.

### Testing
- Ran `pytest tests/configs/test_global_config.py` after making the changes and the tests passed.
- Ran the project test suite with `pytest -q` and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bb834efb4832c93e6092579470a46)

## Summary by Sourcery

Rename the top-level preprocessing configuration from `preprocess` to `preprocessing` across configs, inference logic, tests, and example YAML.

Enhancements:
- Align GlobalConfig, infer pipeline, and test expectations with the new `preprocessing` config block name to improve clarity and consistency.

Tests:
- Update configuration tests and sample YAML to reference the renamed `preprocessing` block and maintain coverage of validation scenarios.