### PR TITLE
Use pathlib.Path for file path construction and update tests

### DIFF
--- a/gaishi/infer.py
+++ b/gaishi/infer.py
@@ -17,6 +17,8 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
+from pathlib import Path
+
 import yaml
 from gaishi.configs import GlobalConfig
 from gaishi.registries.model_registry import MODEL_REGISTRY
@@ -56,13 +58,19 @@ def infer(
             **global_config.preprocessing.model_dump(),
         )
 
-        data = f"{global_config.preprocessing.output_dir}/{global_config.preprocessing.output_prefix}.features"
+        data = str(
+            Path(global_config.preprocessing.output_dir)
+            / f"{global_config.preprocessing.output_prefix}.features"
+        )
     elif global_config.preprocessing.process_type == "genotype_matrix":
         preprocess_genotype_matrices(
             **global_config.preprocessing.model_dump(),
         )
 
-        data = f"{global_config.preprocessing.output_dir}/{global_config.preprocessing.output_prefix}.h5"
+        data = str(
+            Path(global_config.preprocessing.output_dir)
+            / f"{global_config.preprocessing.output_prefix}.h5"
+        )
     else:
         raise ValueError("")
 

--- a/gaishi/train.py
+++ b/gaishi/train.py
@@ -18,8 +18,10 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import os
-import yaml
+from pathlib import Path
 from typing import Optional
+
+import yaml
 from gaishi.configs import GlobalConfig
 from gaishi.registries.model_registry import MODEL_REGISTRY
 from gaishi.simulate import simulate_feature_vectors
@@ -60,7 +62,10 @@ def train(
 
     global_config = GlobalConfig(**config_dict)
     if global_config.simulation.sim_type == "feature_vector":
-        data = f"{global_config.simulation.output_dir}/{global_config.simulation.output_prefix}.tsv"
+        data = str(
+            Path(global_config.simulation.output_dir)
+            / f"{global_config.simulation.output_prefix}.tsv"
+        )
         if not os.path.exists(data):
             print("No training data found. Performing simulation ...")
             simulate_feature_vectors(
@@ -68,7 +73,10 @@ def train(
                 **global_config.simulation.model_dump(),
             )
     elif global_config.simulation.sim_type == "genotype_matrix":
-        data = f"{global_config.simulation.output_dir}/{global_config.simulation.output_prefix}.h5"
+        data = str(
+            Path(global_config.simulation.output_dir)
+            / f"{global_config.simulation.output_prefix}.h5"
+        )
         if not os.path.exists(data):
             print("No training data found. Performing simulation ...")
             simulate_genotype_matrices(

--- a/tests/simulators/test_genotype_matrix_simulator.py
+++ b/tests/simulators/test_genotype_matrix_simulator.py
@@ -17,11 +17,13 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
+from pathlib import Path
+from multiprocessing import Lock, Value
+
 import pytest
 import h5py
 import numpy as np
 import pandas as pd
-from multiprocessing import Lock, Value
 from gaishi.multiprocessing import mp_manager
 from gaishi.generators import RandomNumberGenerator
 from gaishi.simulators import GenotypeMatrixSimulator
@@ -125,7 +127,9 @@ def test_GenotypeMatrixSimulator_h5(init_params_h5):
         lock=Lock(),
     )
 
-    h5_path = f'{init_params_h5["output_dir"]}/{init_params_h5["output_prefix"]}.h5'
+    h5_path = str(
+        Path(init_params_h5["output_dir"]) / f'{init_params_h5["output_prefix"]}.h5'
+    )
 
     with h5py.File(h5_path, "r") as h5f:
         # Required datasets for inputs

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -17,9 +17,13 @@
 #
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
-import h5py, os, pytest
+import os
+from pathlib import Path
+
+import h5py
 import numpy as np
 import pandas as pd
+import pytest
 import gaishi.stats
 from gaishi.preprocess import preprocess_feature_vectors
 from gaishi.preprocess import preprocess_genotype_matrices
@@ -94,7 +98,10 @@ def test_preprocess_feature_vectors(feature_vector_init_params):
 def test_preprocess_genotype_matrices(genotype_matrix_init_params):
     preprocess_genotype_matrices(**genotype_matrix_init_params)
 
-    output_file = f"{genotype_matrix_init_params['output_dir']}/{genotype_matrix_init_params['output_prefix']}.h5"
+    output_file = str(
+        Path(genotype_matrix_init_params["output_dir"])
+        / f"{genotype_matrix_init_params['output_prefix']}.h5"
+    )
 
     with h5py.File(output_file, "r") as f:
         # Meta


### PR DESCRIPTION
### Motivation
- Replace manual string concatenation for file paths with `pathlib.Path` to improve cross-platform correctness and readability.
- Update tests to use the same path construction approach so expected file locations match runtime behavior.

### Description
- In `gaishi/infer.py` replaced f-string path concatenation with `Path(global_config.preprocessing.output_dir) / f"{...}.features"` and `... .h5` to build `data` paths.
- In `gaishi/train.py` added `from pathlib import Path` and switched simulation output path construction to use `Path(...)/...` before checking file existence.
- Updated `tests/simulators/test_genotype_matrix_simulator.py` and `tests/test_preprocess.py` to import `Path` and construct expected output paths using `Path(...) / ...` instead of manual string joins, and adjusted import ordering where needed.
- Applied minor formatting/import adjustments to accommodate the new imports.

### Testing
- Ran `pytest tests/simulators/test_genotype_matrix_simulator.py` which passed.
- Ran `pytest tests/test_preprocess.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2edae249f8832c9b4a02cb6eaed975)

## Summary by Sourcery

Standardize file path construction using pathlib.Path across inference, training, and related tests.

Enhancements:
- Replace manual string concatenation for runtime data file paths in infer and train modules with pathlib.Path-based construction for better portability and clarity.

Tests:
- Update preprocessing and genotype matrix simulator tests to build expected output paths with pathlib.Path and keep them aligned with runtime behavior.