### PR TITLE
Skip simulation and cleanup when too few polymorphisms are produced

### DIFF
--- a/gaishi/simulators/genotype_matrix_simulator.py
+++ b/gaishi/simulators/genotype_matrix_simulator.py
@@ -195,26 +195,38 @@ class GenotypeMatrixSimulator(GenericSimulator):
             The random seed for reproducibility. If not provided, a default value is used.
         """
 
+        if rep is None:
+            rep = 0
+
         file_paths = self.simulator.run(rep=rep, seed=seed)[0]
 
-        labels = self.labeler.run(
-            vcf_file=file_paths["vcf_file"],
-            tgt_ind_file=file_paths["tgt_ind_file"],
-            true_tract_file=file_paths["bed_file"],
-            rep=rep,
-        )
+        try:
+            labels = self.labeler.run(
+                vcf_file=file_paths["vcf_file"],
+                tgt_ind_file=file_paths["tgt_ind_file"],
+                true_tract_file=file_paths["bed_file"],
+                rep=rep,
+            )
 
-        polymorphism_data_generator = PolymorphismDataGenerator(
-            vcf_file=file_paths["vcf_file"],
-            ref_ind_file=file_paths["ref_ind_file"],
-            tgt_ind_file=file_paths["tgt_ind_file"],
-            chr_name="1",
-            random_polymorphisms=True,
-            num_polymorphisms=self.num_polymorphisms,
-            ploidy=self.ploidy,
-            is_phased=self.is_phased,
-            seed=seed,
-        )
+            polymorphism_data_generator = PolymorphismDataGenerator(
+                vcf_file=file_paths["vcf_file"],
+                ref_ind_file=file_paths["ref_ind_file"],
+                tgt_ind_file=file_paths["tgt_ind_file"],
+                chr_name="1",
+                random_polymorphisms=True,
+                num_polymorphisms=self.num_polymorphisms,
+                ploidy=self.ploidy,
+                is_phased=self.is_phased,
+                seed=seed,
+            )
+        except ValueError as e:
+            if self._is_insufficient_polymorphism_error(e):
+                if not self.keep_sim_data:
+                    shutil.rmtree(
+                        os.path.dirname(file_paths["vcf_file"]), ignore_errors=True
+                    )
+                return None
+            raise
 
         preprocessor = GenotypeMatrixPreprocessor(
             ref_ind_file=file_paths["ref_ind_file"],
@@ -256,6 +268,27 @@ class GenotypeMatrixSimulator(GenericSimulator):
 
         if not self.keep_sim_data:
             shutil.rmtree(os.path.dirname(file_paths["vcf_file"]), ignore_errors=True)
+
+    @staticmethod
+    def _is_insufficient_polymorphism_error(error: ValueError) -> bool:
+        """
+        Return whether an error indicates too few polymorphisms in a simulation.
+
+        Parameters
+        ----------
+        error : ValueError
+            Error raised while labeling or sampling simulated polymorphisms.
+
+        Returns
+        -------
+        bool
+            True if the error is caused by insufficient polymorphisms.
+        """
+        message = str(error)
+        return ("Number of polymorphisms" in message and "is less than" in message) or (
+            "No windows could be created with the given number of polymorphisms"
+            in message
+        )
 
     def _output_res(
         self,

--- a/tests/simulators/test_genotype_matrix_simulator.py
+++ b/tests/simulators/test_genotype_matrix_simulator.py
@@ -24,6 +24,7 @@ import pytest
 import h5py
 import numpy as np
 import pandas as pd
+import gaishi.simulators.genotype_matrix_simulator as genotype_matrix_simulator
 from gaishi.multiprocessing import mp_manager
 from gaishi.generators import RandomNumberGenerator
 from gaishi.simulators import GenotypeMatrixSimulator
@@ -187,3 +188,89 @@ def test_GenotypeMatrixSimulator_h5(init_params_h5):
         assert ref0.size > 0 and tgt0.size > 0
         assert np.isfinite(ref0).all()
         assert np.isfinite(tgt0).all()
+
+
+def test_GenotypeMatrixSimulator_skips_too_few_labeler_polymorphisms(
+    init_params, tmp_path
+):
+    simulator = GenotypeMatrixSimulator(**init_params)
+    sim_dir = tmp_path / "sim"
+    sim_dir.mkdir()
+    vcf_file = sim_dir / "rep.vcf"
+    vcf_file.write_text("")
+
+    simulator.simulator.run = lambda rep=None, seed=None: [
+        {
+            "vcf_file": str(vcf_file),
+            "tgt_ind_file": str(sim_dir / "tgt.txt"),
+            "ref_ind_file": str(sim_dir / "ref.txt"),
+            "bed_file": str(sim_dir / "tracts.bed"),
+        }
+    ]
+
+    def raise_too_few_polymorphisms(*args, **kwargs):
+        raise ValueError(
+            f"Number of polymorphisms in {vcf_file} is less than "
+            f"{simulator.num_polymorphisms}."
+        )
+
+    simulator.labeler.run = raise_too_few_polymorphisms
+
+    assert (
+        simulator.run(
+            rep=0,
+            seed=1,
+            force_balanced=False,
+            nintro=Value("i", 0),
+            nnonintro=Value("i", 0),
+            only_intro=False,
+            only_non_intro=False,
+            lock=Lock(),
+        )
+        is None
+    )
+    assert not sim_dir.exists()
+
+
+def test_GenotypeMatrixSimulator_skips_too_few_generator_polymorphisms(
+    init_params, tmp_path, monkeypatch
+):
+    simulator = GenotypeMatrixSimulator(**init_params)
+    sim_dir = tmp_path / "sim"
+    sim_dir.mkdir()
+    vcf_file = sim_dir / "rep.vcf"
+    vcf_file.write_text("")
+
+    simulator.simulator.run = lambda rep=None, seed=None: [
+        {
+            "vcf_file": str(vcf_file),
+            "tgt_ind_file": str(sim_dir / "tgt.txt"),
+            "ref_ind_file": str(sim_dir / "ref.txt"),
+            "bed_file": str(sim_dir / "tracts.bed"),
+        }
+    ]
+    simulator.labeler.run = lambda *args, **kwargs: {}
+
+    def raise_no_windows(*args, **kwargs):
+        raise ValueError(
+            "No windows could be created with the given number of polymorphisms."
+        )
+
+    monkeypatch.setattr(
+        genotype_matrix_simulator, "PolymorphismDataGenerator", raise_no_windows
+    )
+
+    assert (
+        simulator.run(
+            rep=0,
+            seed=1,
+            force_balanced=False,
+            nintro=Value("i", 0),
+            nnonintro=Value("i", 0),
+            only_intro=False,
+            only_non_intro=False,
+            lock=Lock(),
+        )
+        is None
+    )
+    assert not sim_dir.exists()


### PR DESCRIPTION
### Motivation
- Avoid failing the whole pipeline when a simulation produces too few polymorphisms to label or sample and instead skip that replicate and clean up temporary files.
- Make the simulator robust to two known ValueError cases originating from the labeler or polymorphism generator by detecting those specific messages.

### Description
- Wrap the call to `labeler.run` and subsequent `PolymorphismDataGenerator` construction in a `try`/`except` block and return `None` when the error indicates insufficient polymorphisms. 
- Remove temporary simulation data directory using `shutil.rmtree` when a skip occurs unless `keep_sim_data` is `True`.
- Add a helper static method `_is_insufficient_polymorphism_error` to centralize detection of the two known `ValueError` messages.
- Update tests by adding `test_GenotypeMatrixSimulator_skips_too_few_labeler_polymorphisms` and `test_GenotypeMatrixSimulator_skips_too_few_generator_polymorphisms`, and import `gaishi.simulators.genotype_matrix_simulator` in the test module for monkeypatching.

### Testing
- Ran the simulator tests in `tests/simulators/test_genotype_matrix_simulator.py`, including the newly added tests for skipping on insufficient polymorphisms, and they passed.
- The existing `test_GenotypeMatrixSimulator_h5` remained successful after the changes.
- The two new tests verify that `run` returns `None` and that the temporary simulation directory is removed when too few polymorphisms are encountered, and both assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303ace9ab8832cbc82232ac64532ae)

## Summary by Sourcery

Handle simulation runs that produce too few polymorphisms by skipping the replicate and optionally cleaning up temporary data instead of failing.

Bug Fixes:
- Prevent crashes when labeler or polymorphism generator raise specific ValueErrors indicating insufficient polymorphisms by treating them as non-fatal and skipping the replicate.

Enhancements:
- Add centralized detection of insufficient polymorphism errors via a helper method to improve robustness of the genotype matrix simulator.

Tests:
- Add tests to verify that runs with too few polymorphisms from the labeler or generator return None and remove the temporary simulation directory when appropriate.